### PR TITLE
fix: update Hive Mind documentation URLs in CLI help

### DIFF
--- a/src/cli/help-text.js
+++ b/src/cli/help-text.js
@@ -70,8 +70,8 @@ USAGE:
   claude-flow init --sparc         # Initialize with SPARC methodology
   claude-flow help hive-mind       # Learn about Hive Mind features
 
-📚 Documentation: https://github.com/ruvnet/claude-code-flow
-🐝 Hive Mind Guide: https://github.com/ruvnet/claude-code-flow/docs/hive-mind
+📚 Documentation: https://github.com/ruvnet/claude-flow
+🐝 Hive Mind Guide: https://github.com/ruvnet/claude-flow/tree/main/docs/hive-mind
 🐝 ruv-swarm: https://github.com/ruvnet/ruv-FANN/tree/main/ruv-swarm
 `;
 

--- a/src/cli/simple-commands/hive-mind.js
+++ b/src/cli/simple-commands/hive-mind.js
@@ -90,7 +90,7 @@ ${chalk.bold('OPTIONS:')}
   --no-auto-permissions  Disable automatic --dangerously-skip-permissions
 
 ${chalk.bold('For more information:')}
-${chalk.blue('https://github.com/ruvnet/claude-code-flow/docs/hive-mind.md')}
+${chalk.blue('https://github.com/ruvnet/claude-flow/tree/main/docs/hive-mind')}
 `);
 }
 


### PR DESCRIPTION
## Summary
Fixes incorrect URLs in the CLI help text that were causing 404 errors when users tried to access Hive Mind documentation.

## Issues Fixed
- **Repository Name**: Changed from `claude-code-flow` to `claude-flow` (correct repo name)
- **URL Format**: Updated to proper GitHub directory structure `/tree/main/docs/hive-mind`

## Changes Made
### `src/cli/help-text.js`
- Fixed main documentation URL: `https://github.com/ruvnet/claude-flow`
- Fixed Hive Mind guide URL: `https://github.com/ruvnet/claude-flow/tree/main/docs/hive-mind`

### `src/cli/simple-commands/hive-mind.js`
- Fixed Hive Mind documentation URL in command-specific help

## Testing
✅ **Local Testing**: CLI help shows correct URLs
```bash
node src/cli/simple-cli.js --help
# Shows: 🐝 Hive Mind Guide: https://github.com/ruvnet/claude-flow/tree/main/docs/hive-mind
```

✅ **URL Verification**: All URLs return HTTP 200
- `https://github.com/ruvnet/claude-flow` → ✅ 200
- `https://github.com/ruvnet/claude-flow/tree/main/docs/hive-mind` → ✅ 200

## Impact
- Users can now access Hive Mind documentation from CLI help
- Eliminates 404 errors when clicking documentation links
- Improves user experience and documentation accessibility

## Before/After
**Before**: `https://github.com/ruvnet/claude-code-flow/docs/hive-mind` → 404 ❌
**After**: `https://github.com/ruvnet/claude-flow/tree/main/docs/hive-mind` → 200 ✅

Ready to merge\!