### PR TITLE
Fix: Correct npm package name for Claude Code installation

### DIFF
--- a/docs/user-guide-v2.md
+++ b/docs/user-guide-v2.md
@@ -48,7 +48,7 @@ Claude Flow v2.0.0 is designed to work seamlessly with Claude Code:
 
 ```bash
 # Install Claude Code if not already installed
-npm install -g @anthropic/claude-code
+npm install -g @anthropic-ai/claude-code
 
 # Add Claude Flow as an MCP server
 claude mcp add claude-flow npx claude-flow@2.0.0 mcp start

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "2.0.0-alpha.35",
+  "version": "2.0.0-alpha.36",
   "description": "Enterprise-grade AI agent orchestration with ruv-swarm integration (Alpha Release)",
   "main": "cli.mjs",
   "bin": {

--- a/src/cli/simple-commands/hive-mind.js
+++ b/src/cli/simple-commands/hive-mind.js
@@ -1602,7 +1602,7 @@ async function spawnClaudeCodeInstances(swarmId, swarmName, objective, workers, 
         claudeAvailable = true;
       } catch {
         console.log(chalk.yellow('\n⚠️  Claude Code CLI not found in PATH'));
-        console.log(chalk.gray('Install it with: npm install -g @anthropic/claude-code-cli'));
+        console.log(chalk.gray('Install it with: npm install -g @anthropic-ai/claude-code'));
         console.log(chalk.gray('\nFalling back to displaying instructions...'));
       }
       
@@ -1646,7 +1646,7 @@ async function spawnClaudeCodeInstances(swarmId, swarmName, objective, workers, 
         console.log(chalk.yellow('\n📋 Manual Execution Instructions:'));
         console.log(chalk.gray('─'.repeat(50)));
         console.log(chalk.gray('1. Install Claude Code:'));
-        console.log(chalk.green('   npm install -g @anthropic/claude-code-cli'));
+        console.log(chalk.green('   npm install -g @anthropic-ai/claude-code'));
         console.log(chalk.gray('\n2. Run with the saved prompt:'));
         console.log(chalk.green(`   claude < ${promptFile}`));
         console.log(chalk.gray('\n3. Or copy the prompt manually:'));

--- a/src/cli/simple-commands/swarm.js
+++ b/src/cli/simple-commands/swarm.js
@@ -115,7 +115,7 @@ export async function swarmCommand(args, flags) {
         claudeAvailable = true;
       } catch {
         console.log('⚠️  Claude Code CLI not found in PATH');
-        console.log('Install it with: npm install -g @anthropic/claude-code-cli');
+        console.log('Install it with: npm install -g @anthropic-ai/claude-code');
         console.log('\nWould spawn Claude Code with swarm objective:');
         console.log(`📋 Objective: ${objective}`);
         console.log('\nTo use the built-in executor instead: claude-flow swarm "objective" --executor');


### PR DESCRIPTION
## Summary

This PR fixes the incorrect npm package name for Claude Code installation instructions throughout the codebase.

## Problem
When users don't have Claude Code installed, the error messages showed:
```bash
npm install -g @anthropic/claude-code-cli
```

This package doesn't exist on npm, causing installation failures.

## Solution  
Updated all references to use the correct package name:
```bash
npm install -g @anthropic-ai/claude-code
```

## Changes
- 🔧 Fixed `src/cli/simple-commands/hive-mind.js` (2 occurrences)
- 🔧 Fixed `src/cli/simple-commands/swarm.js` (1 occurrence)
- 📚 Fixed `docs/user-guide-v2.md` documentation

## Testing
- ✅ Published as v2.0.0-alpha.36
- ✅ Available on npm registry
- ✅ Installation instructions now show correct package

## Related
- Fixes #187

## Impact
Users will now be able to successfully install Claude Code when prompted by the error messages.