### PR TITLE
chore: bump version to 2.0.0-alpha.43 to match npm registry

### DIFF
--- a/bin/claude-flow
+++ b/bin/claude-flow
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Claude-Flow Smart Dispatcher - Detects and uses the best available runtime
 
-VERSION="2.0.0-alpha.42"
+VERSION="2.0.0-alpha.43"
 
 # Determine the correct path based on how the script is invoked
 if [ -L "$0" ]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "2.0.0-alpha.42",
+  "version": "2.0.0-alpha.43",
   "description": "Enterprise-grade AI agent orchestration with ruv-swarm integration (Alpha Release)",
   "main": "cli.mjs",
   "bin": {

--- a/src/cli/help-text.js
+++ b/src/cli/help-text.js
@@ -3,7 +3,7 @@
  * Provides clear, actionable command documentation
  */
 
-export const VERSION = '2.0.0-alpha.42';
+export const VERSION = '2.0.0-alpha.43';
 
 export const MAIN_HELP = `
 🌊 Claude-Flow v${VERSION} - Enterprise-Grade AI Agent Orchestration Platform


### PR DESCRIPTION
This pull request updates the version of the `claude-flow` package from `2.0.0-alpha.42` to `2.0.0-alpha.43`. The changes ensure consistency in versioning across the `package.json` file and the `VERSION` constant in the CLI help text.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the `version` field to `2.0.0-alpha.43`.
* [`src/cli/help-text.js`](diffhunk://#diff-08fd733355b57f09e9c369dfa36580f937678ba21511cd88cffe7e5ec088f32aL6-R6): Updated the `VERSION` constant to `2.0.0-alpha.43` to match the new package version.