### PR TITLE
Update .claude/settings.json to new Claude CLI hooks format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,36 +34,57 @@
     ]
   },
   "hooks": {
-    "preEditHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "pre-edit", "--file", "${file}", "--auto-assign-agents", "true", "--load-context", "true"],
-      "alwaysRun": false,
-      "outputFormat": "json"
-    },
-    "postEditHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "post-edit", "--file", "${file}", "--format", "true", "--update-memory", "true", "--train-neural", "true"],
-      "alwaysRun": true,
-      "outputFormat": "json"
-    },
-    "preCommandHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "pre-command", "--command", "${command}", "--validate-safety", "true", "--prepare-resources", "true"],
-      "alwaysRun": false,
-      "outputFormat": "json"
-    },
-    "postCommandHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "post-command", "--command", "${command}", "--track-metrics", "true", "--store-results", "true"],
-      "alwaysRun": false,
-      "outputFormat": "json"
-    },
-    "sessionEndHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "session-end", "--generate-summary", "true", "--persist-state", "true", "--export-metrics", "true"],
-      "alwaysRun": true,
-      "outputFormat": "json"
-    }
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hooks pre-command --command \"${command}\" --validate-safety true --prepare-resources true"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hooks pre-edit --file \"${file}\" --auto-assign-agents true --load-context true"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hooks post-command --command \"${command}\" --track-metrics true --store-results true"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hooks post-edit --file \"${file}\" --format true --update-memory true --train-neural true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hooks session-end --generate-summary true --persist-state true --export-metrics true"
+          }
+        ]
+      }
+    ]
   },
   "mcpServers": {
     "claude-flow": {


### PR DESCRIPTION
## Summary
Updates the hooks configuration in `.claude/settings.json` to use the new Claude CLI hooks format (v1.0.51+).

## Changes
- Converts from deprecated `preEditHook`, `postEditHook`, etc. object format
- Updates to new `PreToolUse`/`PostToolUse` array format with matchers
- Removes unsupported `alwaysRun` and `outputFormat` properties
- Maintains all existing hook functionality

## Why this change is needed
The current hooks format causes validation errors in Claude CLI 1.0.51+:
```
Invalid Settings
├ postCommandHook: Expected array, but received object
├ postEditHook: Expected array, but received object
├ preCommandHook: Expected array, but received object
├ preEditHook: Expected array, but received object
└ sessionEndHook: Expected array, but received object
```

## Hook Conversion Mapping
- `preCommandHook` → `PreToolUse` with `"matcher": "Bash"`
- `postCommandHook` → `PostToolUse` with `"matcher": "Bash"`
- `preEditHook` → `PreToolUse` with `"matcher": "Write|Edit|MultiEdit"`
- `postEditHook` → `PostToolUse` with `"matcher": "Write|Edit|MultiEdit"`
- `sessionEndHook` → `Stop` with `"matcher": ""` (empty = all events)

## Testing
✅ Tested with Claude CLI 1.0.51  
✅ All hooks execute correctly  
✅ No validation errors  
✅ Maintains backward compatibility for claude-flow commands

## Documentation Reference
Based on official Claude CLI documentation: https://docs.anthropic.com/en/docs/claude-code/hooks

Fixes compatibility with current Claude CLI versions and eliminates validation warnings.