### PR TITLE
fix: update the templates used by init to use correct claude code syntax and IO

### DIFF
--- a/src/cli/simple-commands/init/index.js
+++ b/src/cli/simple-commands/init/index.js
@@ -1023,6 +1023,10 @@ async function enhancedClaudeFlowInit(flags, subArgs = []) {
           "mcp__ruv-swarm",
           "mcp__claude-flow"
         ],
+        "enabledMcpjsonServers": [
+          "claude-flow",
+          "ruv-swarm"
+        ],
         "deny": []
       }
     };

--- a/src/cli/simple-commands/init/templates/enhanced-templates.js
+++ b/src/cli/simple-commands/init/templates/enhanced-templates.js
@@ -1259,39 +1259,60 @@ function createEnhancedSettingsJsonFallback() {
         "Bash(eval *)"
       ]
     },
-    hooks: {
-      preEditHook: {
-        command: "npx",
-        args: ["claude-flow", "hook", "pre-edit", "--file", "${file}", "--auto-assign-agents", "true", "--load-context", "true"],
-        alwaysRun: false,
-        outputFormat: "json"
-      },
-      postEditHook: {
-        command: "npx",
-        args: ["claude-flow", "hook", "post-edit", "--file", "${file}", "--format", "true", "--update-memory", "true", "--train-neural", "true"],
-        alwaysRun: true,
-        outputFormat: "json"
-      },
-      preCommandHook: {
-        command: "npx",
-        args: ["claude-flow", "hook", "pre-command", "--command", "${command}", "--validate-safety", "true", "--prepare-resources", "true"],
-        alwaysRun: false,
-        outputFormat: "json"
-      },
-      postCommandHook: {
-        command: "npx",
-        args: ["claude-flow", "hook", "post-command", "--command", "${command}", "--track-metrics", "true", "--store-results", "true"],
-        alwaysRun: false,
-        outputFormat: "json"
-      },
-      sessionEndHook: {
-        command: "npx",
-        args: ["claude-flow", "hook", "session-end", "--generate-summary", "true", "--persist-state", "true", "--export-metrics", "true"],
-        alwaysRun: true,
-        outputFormat: "json"
-      }
+   "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Bash",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "COMMAND=$(jq -r '.tool_input.command') && npx claude-flow hooks pre-command --command \"$COMMAND\" --validate-safety true --prepare-resources true"
+            }
+          ]
+        },
+        {
+          "matcher": "Write|Edit|MultiEdit",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "FILE_PATH=$(jq -r '.tool_input.file_path') && npx claude-flow hooks pre-edit --file \"$FILE_PATH\" --auto-assign-agents true --load-context true"
+            }
+          ]
+        }
+      ],
+      "PostToolUse": [
+        {
+          "matcher": "Bash",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "COMMAND=$(jq -r '.tool_input.command') && npx claude-flow hooks post-command --command \"$COMMAND\" --track-metrics true --store-results true"
+            }
+          ]
+        },
+        {
+          "matcher": "Write|Edit|MultiEdit",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "FILE_PATH=$(jq -r '.tool_input.file_path') && npx claude-flow hooks post-edit --file \"$FILE_PATH\" --format true --update-memory true --train-neural true"
+            }
+          ]
+        }
+      ],
+      "Stop": [
+        {
+          "matcher": "",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "npx claude-flow hooks session-end --generate-summary true --persist-state true --export-metrics true"
+            }
+          ]
+        }
+      ]
     },
-    mcpServers: {
+   mcpServers: {
       "claude-flow": {
         command: "npx",
         args: ["claude-flow", "mcp", "start"],

--- a/src/cli/simple-commands/init/templates/enhanced-templates.js
+++ b/src/cli/simple-commands/init/templates/enhanced-templates.js
@@ -1312,36 +1312,6 @@ function createEnhancedSettingsJsonFallback() {
         }
       ]
     },
-   mcpServers: {
-      "claude-flow": {
-        command: "npx",
-        args: ["claude-flow", "mcp", "start"],
-        env: {
-          CLAUDE_FLOW_HOOKS_ENABLED: "true",
-          CLAUDE_FLOW_TELEMETRY_ENABLED: "true",
-          CLAUDE_FLOW_REMOTE_READY: "true",
-          CLAUDE_FLOW_GITHUB_INTEGRATION: "true"
-        }
-      }
-    },
-    includeCoAuthoredBy: true,
-    features: {
-      autoTopologySelection: true,
-      parallelExecution: true,
-      neuralTraining: true,
-      bottleneckAnalysis: true,
-      smartAutoSpawning: true,
-      selfHealingWorkflows: true,
-      crossSessionMemory: true,
-      githubIntegration: true
-    },
-    performance: {
-      maxAgents: 10,
-      defaultTopology: "hierarchical",
-      executionStrategy: "parallel",
-      tokenOptimization: true,
-      cacheEnabled: true,
-      telemetryLevel: "detailed"
-    }
+    includeCoAuthoredBy: true
   }, null, 2);
 }

--- a/src/cli/simple-commands/init/templates/settings.json
+++ b/src/cli/simple-commands/init/templates/settings.json
@@ -33,38 +33,59 @@
       "Bash(eval *)"
     ]
   },
-  "hooks": {
-    "preEditHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "pre-edit", "--file", "${file}", "--auto-assign-agents", "true", "--load-context", "true"],
-      "alwaysRun": false,
-      "outputFormat": "json"
+   "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Bash",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "COMMAND=$(jq -r '.tool_input.command') && npx claude-flow hooks pre-command --command \"$COMMAND\" --validate-safety true --prepare-resources true"
+            }
+          ]
+        },
+        {
+          "matcher": "Write|Edit|MultiEdit",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "FILE_PATH=$(jq -r '.tool_input.file_path') && npx claude-flow hooks pre-edit --file \"$FILE_PATH\" --auto-assign-agents true --load-context true"
+            }
+          ]
+        }
+      ],
+      "PostToolUse": [
+        {
+          "matcher": "Bash",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "COMMAND=$(jq -r '.tool_input.command') && npx claude-flow hooks post-command --command \"$COMMAND\" --track-metrics true --store-results true"
+            }
+          ]
+        },
+        {
+          "matcher": "Write|Edit|MultiEdit",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "FILE_PATH=$(jq -r '.tool_input.file_path') && npx claude-flow hooks post-edit --file \"$FILE_PATH\" --format true --update-memory true --train-neural true"
+            }
+          ]
+        }
+      ],
+      "Stop": [
+        {
+          "matcher": "",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "npx claude-flow hooks session-end --generate-summary true --persist-state true --export-metrics true"
+            }
+          ]
+        }
+      ]
     },
-    "postEditHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "post-edit", "--file", "${file}", "--format", "true", "--update-memory", "true", "--train-neural", "true"],
-      "alwaysRun": true,
-      "outputFormat": "json"
-    },
-    "preCommandHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "pre-command", "--command", "${command}", "--validate-safety", "true", "--prepare-resources", "true"],
-      "alwaysRun": false,
-      "outputFormat": "json"
-    },
-    "postCommandHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "post-command", "--command", "${command}", "--track-metrics", "true", "--store-results", "true"],
-      "alwaysRun": false,
-      "outputFormat": "json"
-    },
-    "sessionEndHook": {
-      "command": "npx",
-      "args": ["claude-flow", "hooks", "session-end", "--generate-summary", "true", "--persist-state", "true", "--export-metrics", "true"],
-      "alwaysRun": true,
-      "outputFormat": "json"
-    }
-  },
   "mcpServers": {
     "claude-flow": {
       "command": "npx",

--- a/src/cli/simple-commands/init/templates/settings.json
+++ b/src/cli/simple-commands/init/templates/settings.json
@@ -33,92 +33,58 @@
       "Bash(eval *)"
     ]
   },
-   "hooks": {
-      "PreToolUse": [
-        {
-          "matcher": "Bash",
-          "hooks": [
-            {
-              "type": "command",
-              "command": "COMMAND=$(jq -r '.tool_input.command') && npx claude-flow hooks pre-command --command \"$COMMAND\" --validate-safety true --prepare-resources true"
-            }
-          ]
-        },
-        {
-          "matcher": "Write|Edit|MultiEdit",
-          "hooks": [
-            {
-              "type": "command",
-              "command": "FILE_PATH=$(jq -r '.tool_input.file_path') && npx claude-flow hooks pre-edit --file \"$FILE_PATH\" --auto-assign-agents true --load-context true"
-            }
-          ]
-        }
-      ],
-      "PostToolUse": [
-        {
-          "matcher": "Bash",
-          "hooks": [
-            {
-              "type": "command",
-              "command": "COMMAND=$(jq -r '.tool_input.command') && npx claude-flow hooks post-command --command \"$COMMAND\" --track-metrics true --store-results true"
-            }
-          ]
-        },
-        {
-          "matcher": "Write|Edit|MultiEdit",
-          "hooks": [
-            {
-              "type": "command",
-              "command": "FILE_PATH=$(jq -r '.tool_input.file_path') && npx claude-flow hooks post-edit --file \"$FILE_PATH\" --format true --update-memory true --train-neural true"
-            }
-          ]
-        }
-      ],
-      "Stop": [
-        {
-          "matcher": "",
-          "hooks": [
-            {
-              "type": "command",
-              "command": "npx claude-flow hooks session-end --generate-summary true --persist-state true --export-metrics true"
-            }
-          ]
-        }
-      ]
-    },
-  "mcpServers": {
-    "claude-flow": {
-      "command": "npx",
-      "args": [
-        "claude-flow",
-        "mcp",
-        "start"
-      ],
-      "env": {
-        "CLAUDE_FLOW_HOOKS_ENABLED": "true",
-        "CLAUDE_FLOW_TELEMETRY_ENABLED": "true",
-        "CLAUDE_FLOW_REMOTE_READY": "true",
-        "CLAUDE_FLOW_GITHUB_INTEGRATION": "true"
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "COMMAND=$(jq -r '.tool_input.command') && npx claude-flow hooks pre-command --command \"$COMMAND\" --validate-safety true --prepare-resources true"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE_PATH=$(jq -r '.tool_input.file_path') && npx claude-flow hooks pre-edit --file \"$FILE_PATH\" --auto-assign-agents true --load-context true"
+          }
+        ]
       }
-    }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "COMMAND=$(jq -r '.tool_input.command') && npx claude-flow hooks post-command --command \"$COMMAND\" --track-metrics true --store-results true"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE_PATH=$(jq -r '.tool_input.file_path') && npx claude-flow hooks post-edit --file \"$FILE_PATH\" --format true --update-memory true --train-neural true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hooks session-end --generate-summary true --persist-state true --export-metrics true"
+          }
+        ]
+      }
+    ]
   },
-  "includeCoAuthoredBy": true,
-  "features": {
-    "autoTopologySelection": true,
-    "parallelExecution": true,
-    "neuralTraining": true,
-    "bottleneckAnalysis": true,
-    "smartAutoSpawning": true,
-    "selfHealingWorkflows": true,
-    "crossSessionMemory": true,
-    "githubIntegration": true
-  },
-  "performance": {
-    "maxAgents": 10,
-    "defaultTopology": "hierarchical",
-    "executionStrategy": "parallel",
-    "tokenOptimization": true,
-    "cacheEnabled": true,
-    "telemetryLevel": "detailed"
-  }
+  "includeCoAuthoredBy": true
 }


### PR DESCRIPTION
The claude code hook json format seems to have changed very recently. Hook commands get a json payload from stdin. In order to populate the `npx claude-flow...` commands we need to extract the fields that we need from the payload.

https://docs.anthropic.com/en/docs/claude-code/hooks

The old init command was generating syntax that claude code v1.0.51 did not accept and doctor said

  └ hooks
    ├ postCommandHook: Expected array, but received object
    ├ postEditHook: Expected array, but received object
    ├ preCommandHook: Expected array, but received object
    ├ preEditHook: Expected array, but received object
    └ sessionEndHook: Expected array, but received object
