### PR TITLE
Convert MCP integration wrapper to TypeScript

### DIFF
--- a/docs/mcp-protocol-analysis.md
+++ b/docs/mcp-protocol-analysis.md
@@ -1,0 +1,215 @@
+# MCP Protocol Analysis - TypeScript Conversion Requirements
+
+## Current State Analysis
+
+The Claude Flow MCP integration has the following structure:
+
+### 1. TypeScript Interfaces (src/utils/types.ts)
+✅ **Complete Protocol Type Definitions**
+- `MCPProtocolVersion`: Protocol version (2024-11-05)
+- `MCPCapabilities`: Server/client capabilities
+- `MCPInitializeParams`, `MCPInitializeResult`: Initialization handshake
+- `MCPTool`, `MCPPrompt`, `MCPResource`: Core features
+- `MCPRequest`, `MCPResponse`, `MCPNotification`: JSON-RPC messages
+- `MCPError`, `MCPToolCall`, `MCPToolResult`: Error handling & execution
+- `MCPSession`, `MCPAuthConfig`: Session management
+- `MCPMetrics`: Performance monitoring
+
+### 2. JavaScript Implementation Files (Need TypeScript Conversion)
+❌ **src/mcp/mcp-server.js** - Main MCP server implementation
+❌ **src/mcp/ruv-swarm-wrapper.js** - Ruv-swarm integration wrapper
+
+### 3. TypeScript MCP Server (src/mcp/server.ts)
+✅ **Comprehensive MCP Server Implementation**
+- Full protocol compliance with JSON-RPC 2.0
+- Tool registry with 100+ tools
+- Session management with authentication
+- Transport layer (stdio, HTTP, WebSocket)
+- Load balancing and performance monitoring
+- Integration with orchestration components
+
+## Protocol Compliance Requirements
+
+### JSON-RPC 2.0 Message Types
+
+1. **Requests** (Client ↔ Server)
+   ```typescript
+   interface MCPRequest {
+     jsonrpc: '2.0';
+     id: string | number;  // MUST NOT be null
+     method: string;
+     params?: unknown;
+   }
+   ```
+
+2. **Responses** (Reply to Requests)
+   ```typescript
+   interface MCPResponse {
+     jsonrpc: '2.0';
+     id: string | number;  // Same as request ID
+     result?: unknown;     // Either result OR error
+     error?: MCPError;     // MUST NOT have both
+   }
+   ```
+
+3. **Notifications** (One-way Messages)
+   ```typescript
+   interface MCPNotification {
+     jsonrpc: '2.0';
+     method: string;
+     params?: unknown;
+     // NO id field
+   }
+   ```
+
+### Core Protocol Methods
+
+1. **initialize** - Protocol handshake
+2. **tools/list** - List available tools
+3. **tools/call** - Execute tool
+4. **resources/list** - List available resources
+5. **resources/read** - Read resource content
+6. **prompts/list** - List available prompts
+7. **prompts/get** - Get prompt definition
+8. **logging/setLevel** - Set logging level
+
+### Message Flow Requirements
+
+1. **Initialization Sequence**
+   - Client sends `initialize` request
+   - Server responds with capabilities
+   - Client sends `initialized` notification
+
+2. **Tool Execution**
+   - Client sends `tools/call` request
+   - Server executes tool and returns result
+   - Results include content array with text/image/resource types
+
+3. **Resource Access**
+   - Client sends `resources/list` request
+   - Server returns available resources
+   - Client sends `resources/read` for specific resource
+
+## TypeScript Conversion Strategy
+
+### 1. Convert mcp-server.js to TypeScript
+
+**Current Issues:**
+- JavaScript implementation with manual type checking
+- Missing proper type safety for tool parameters
+- No compile-time validation of protocol compliance
+
+**Target TypeScript Structure:**
+```typescript
+export class ClaudeFlowMCPServer implements IMCPServer {
+  private tools: Map<string, MCPTool>;
+  private resources: Map<string, MCPResource>;
+  private memoryStore: EnhancedMemory;
+  private sessionId: string;
+  
+  constructor(
+    private config: MCPConfig,
+    private logger: ILogger
+  ) {}
+  
+  async handleMessage(message: MCPRequest): Promise<MCPResponse> {
+    // Type-safe message handling
+  }
+  
+  async executeTool(name: string, args: unknown): Promise<MCPToolResult> {
+    // Type-safe tool execution
+  }
+}
+```
+
+### 2. Convert ruv-swarm-wrapper.js to TypeScript
+
+**Current Issues:**
+- Process management without proper typing
+- Error handling without structured types
+- No interface definitions for wrapper methods
+
+**Target TypeScript Structure:**
+```typescript
+export class RuvSwarmWrapper {
+  private process: ChildProcess | null = null;
+  private options: RuvSwarmOptions;
+  
+  constructor(options: RuvSwarmOptions = {}) {}
+  
+  async start(): Promise<RuvSwarmInstance> {
+    // Type-safe process management
+  }
+  
+  async stop(): Promise<void> {
+    // Graceful shutdown
+  }
+}
+```
+
+### 3. Integration with Existing TypeScript Server
+
+The existing `src/mcp/server.ts` is already comprehensive and TypeScript-compliant. The conversion should:
+
+1. **Migrate tools** from mcp-server.js to server.ts
+2. **Merge capabilities** from both implementations
+3. **Preserve ruv-swarm integration** with proper types
+4. **Maintain backward compatibility** with existing clients
+
+## Implementation Plan
+
+### Phase 1: Tool Migration
+1. Extract tool definitions from mcp-server.js
+2. Convert to TypeScript with proper schemas
+3. Add to existing server.ts tool registry
+4. Implement type-safe tool execution
+
+### Phase 2: Wrapper Conversion
+1. Convert ruv-swarm-wrapper.js to TypeScript
+2. Add proper interface definitions
+3. Integrate with main server architecture
+4. Add error handling and logging
+
+### Phase 3: Integration & Testing
+1. Ensure protocol compliance
+2. Test with real MCP clients
+3. Performance benchmarking
+4. Documentation updates
+
+## Key Protocol Considerations
+
+### 1. Tool Schema Validation
+- All tool parameters must be validated against JSON Schema
+- Input/output types must be properly typed
+- Error responses must follow MCP error format
+
+### 2. Resource Management
+- Resources must be properly typed
+- URI schemes must follow MCP conventions
+- Content types must be correctly specified
+
+### 3. Session Management
+- Session lifecycle must be properly managed
+- Authentication must be implemented if enabled
+- Metrics must be collected and exposed
+
+### 4. Error Handling
+- All errors must follow MCP error format
+- Error codes must be standard JSON-RPC codes
+- Detailed error information in `data` field
+
+## Success Criteria
+
+✅ **Type Safety**: All MCP messages and handlers are type-safe
+✅ **Protocol Compliance**: Full JSON-RPC 2.0 and MCP spec compliance
+✅ **Tool Integration**: All 100+ tools working with proper types
+✅ **Performance**: No performance degradation from TypeScript conversion
+✅ **Compatibility**: Existing MCP clients continue to work
+✅ **Testing**: Comprehensive test coverage for protocol compliance
+
+## Next Steps
+
+1. **Begin Phase 1**: Start with tool migration from mcp-server.js
+2. **Set up testing**: Create protocol compliance tests
+3. **Incremental conversion**: Convert one component at a time
+4. **Validation**: Test with real MCP clients throughout process

--- a/src/mcp/generics.ts
+++ b/src/mcp/generics.ts
@@ -1,0 +1,928 @@
+/**
+ * Generic utility types and functions for MCP protocol
+ * Provides type-safe generic operations and utilities for extensibility
+ */
+
+import {
+  MCPTool,
+  MCPPrompt,
+  MCPResource,
+  MCPContext,
+  MCPSession,
+  MCPEvent,
+  MCPToolResult,
+  MCPPromptMessage,
+  MCPResourceContent,
+  JSONRPCMessage,
+  JSONRPCRequest,
+  JSONRPCResponse,
+  MCPError,
+  MCPErrorCode,
+  MCPCapabilities,
+  MCPProtocolVersion,
+  JSONSchema,
+  MCPEventType,
+  MCPLogLevel,
+  MCPTransportType,
+  MCPAuthMethod,
+  MCPSessionState
+} from './types.js';
+
+import { createMCPError, isMCPError } from './type-guards.js';
+
+// ================================================================
+// GENERIC UTILITY TYPES
+// ================================================================
+
+/**
+ * Utility type for extracting keys from an object type
+ */
+export type Keys<T> = keyof T;
+
+/**
+ * Utility type for extracting values from an object type
+ */
+export type Values<T> = T[keyof T];
+
+/**
+ * Utility type for making all properties optional recursively
+ */
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+/**
+ * Utility type for making all properties required recursively
+ */
+export type DeepRequired<T> = {
+  [P in keyof T]-?: T[P] extends object ? DeepRequired<T[P]> : T[P];
+};
+
+/**
+ * Utility type for picking properties by type
+ */
+export type PickByType<T, U> = {
+  [K in keyof T as T[K] extends U ? K : never]: T[K];
+};
+
+/**
+ * Utility type for omitting properties by type
+ */
+export type OmitByType<T, U> = {
+  [K in keyof T as T[K] extends U ? never : K]: T[K];
+};
+
+/**
+ * Utility type for creating a union from array elements
+ */
+export type ArrayElement<T extends readonly unknown[]> = T[number];
+
+/**
+ * Utility type for creating a type from enum values
+ */
+export type EnumValues<T extends Record<string, string | number>> = T[keyof T];
+
+/**
+ * Utility type for extracting function parameters
+ */
+export type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? P : never;
+
+/**
+ * Utility type for extracting function return type
+ */
+export type ReturnType<T extends (...args: any[]) => any> = T extends (...args: any[]) => infer R ? R : any;
+
+/**
+ * Utility type for extracting Promise value type
+ */
+export type PromiseValue<T> = T extends Promise<infer U> ? U : T;
+
+/**
+ * Utility type for creating a branded type
+ */
+export type Brand<T, B> = T & { __brand: B };
+
+/**
+ * Utility type for creating a nominal type
+ */
+export type Nominal<T, K extends string> = T & { __nominal: K };
+
+// ================================================================
+// MCP-SPECIFIC GENERIC TYPES
+// ================================================================
+
+/**
+ * Generic MCP handler function type
+ */
+export type MCPHandler<TInput = unknown, TOutput = unknown, TContext extends MCPContext = MCPContext> = (
+  input: TInput,
+  context?: TContext
+) => Promise<TOutput>;
+
+/**
+ * Generic MCP tool with typed input/output
+ */
+export interface TypedMCPTool<
+  TName extends string = string,
+  TInput = unknown,
+  TOutput = unknown,
+  TContext extends MCPContext = MCPContext
+> extends Omit<MCPTool, 'name' | 'handler'> {
+  name: TName;
+  handler: MCPHandler<TInput, TOutput, TContext>;
+}
+
+/**
+ * Generic MCP prompt with typed arguments
+ */
+export interface TypedMCPPrompt<
+  TName extends string = string,
+  TArgs extends Record<string, any> = Record<string, any>
+> extends Omit<MCPPrompt, 'name'> {
+  name: TName;
+  arguments?: Array<{
+    name: keyof TArgs;
+    description?: string;
+    required?: boolean;
+  }>;
+}
+
+/**
+ * Generic MCP resource with typed content
+ */
+export interface TypedMCPResource<
+  TUri extends string = string,
+  TContent = unknown
+> extends Omit<MCPResource, 'uri'> {
+  uri: TUri;
+  content?: TContent;
+}
+
+/**
+ * Generic MCP session with typed metadata
+ */
+export interface TypedMCPSession<
+  TMetadata extends Record<string, any> = Record<string, any>
+> extends Omit<MCPSession, 'metadata'> {
+  metadata?: TMetadata;
+}
+
+/**
+ * Generic MCP event with typed data
+ */
+export interface TypedMCPEvent<
+  TType extends MCPEventType = MCPEventType,
+  TData = unknown,
+  TMetadata extends Record<string, any> = Record<string, any>
+> extends Omit<MCPEvent, 'type' | 'data' | 'metadata'> {
+  type: TType;
+  data: TData;
+  metadata?: TMetadata;
+}
+
+/**
+ * Generic MCP context with typed metadata
+ */
+export interface TypedMCPContext<
+  TMetadata extends Record<string, any> = Record<string, any>
+> extends Omit<MCPContext, 'metadata'> {
+  metadata?: TMetadata;
+}
+
+/**
+ * Generic JSON-RPC request with typed parameters
+ */
+export interface TypedJSONRPCRequest<
+  TMethod extends string = string,
+  TParams = unknown
+> extends Omit<JSONRPCRequest, 'method' | 'params'> {
+  method: TMethod;
+  params?: TParams;
+}
+
+/**
+ * Generic JSON-RPC response with typed result
+ */
+export interface TypedJSONRPCResponse<
+  TResult = unknown
+> extends Omit<JSONRPCResponse, 'result'> {
+  result?: TResult;
+}
+
+// ================================================================
+// GENERIC COLLECTIONS
+// ================================================================
+
+/**
+ * Generic registry for MCP components
+ */
+export class MCPRegistry<T> {
+  private items = new Map<string, T>();
+  private metadata = new Map<string, Record<string, any>>();
+  
+  /**
+   * Registers an item with optional metadata
+   */
+  register(name: string, item: T, metadata?: Record<string, any>): void {
+    this.items.set(name, item);
+    if (metadata) {
+      this.metadata.set(name, metadata);
+    }
+  }
+  
+  /**
+   * Unregisters an item
+   */
+  unregister(name: string): boolean {
+    this.metadata.delete(name);
+    return this.items.delete(name);
+  }
+  
+  /**
+   * Gets an item by name
+   */
+  get(name: string): T | undefined {
+    return this.items.get(name);
+  }
+  
+  /**
+   * Gets metadata for an item
+   */
+  getMetadata(name: string): Record<string, any> | undefined {
+    return this.metadata.get(name);
+  }
+  
+  /**
+   * Checks if an item exists
+   */
+  has(name: string): boolean {
+    return this.items.has(name);
+  }
+  
+  /**
+   * Lists all registered names
+   */
+  list(): string[] {
+    return Array.from(this.items.keys());
+  }
+  
+  /**
+   * Gets all items as an array
+   */
+  getAll(): Array<{ name: string; item: T; metadata?: Record<string, any> }> {
+    return Array.from(this.items.entries()).map(([name, item]) => ({
+      name,
+      item,
+      metadata: this.metadata.get(name)
+    }));
+  }
+  
+  /**
+   * Clears all items
+   */
+  clear(): void {
+    this.items.clear();
+    this.metadata.clear();
+  }
+  
+  /**
+   * Gets the number of registered items
+   */
+  size(): number {
+    return this.items.size;
+  }
+  
+  /**
+   * Executes a function for each item
+   */
+  forEach(callback: (item: T, name: string, metadata?: Record<string, any>) => void): void {
+    for (const [name, item] of this.items) {
+      callback(item, name, this.metadata.get(name));
+    }
+  }
+  
+  /**
+   * Filters items by a predicate
+   */
+  filter(predicate: (item: T, name: string, metadata?: Record<string, any>) => boolean): Array<{ name: string; item: T; metadata?: Record<string, any> }> {
+    const results: Array<{ name: string; item: T; metadata?: Record<string, any> }> = [];
+    
+    for (const [name, item] of this.items) {
+      const metadata = this.metadata.get(name);
+      if (predicate(item, name, metadata)) {
+        results.push({ name, item, metadata });
+      }
+    }
+    
+    return results;
+  }
+  
+  /**
+   * Maps items to a new array
+   */
+  map<U>(mapper: (item: T, name: string, metadata?: Record<string, any>) => U): U[] {
+    const results: U[] = [];
+    
+    for (const [name, item] of this.items) {
+      const metadata = this.metadata.get(name);
+      results.push(mapper(item, name, metadata));
+    }
+    
+    return results;
+  }
+  
+  /**
+   * Finds the first item matching a predicate
+   */
+  find(predicate: (item: T, name: string, metadata?: Record<string, any>) => boolean): { name: string; item: T; metadata?: Record<string, any> } | undefined {
+    for (const [name, item] of this.items) {
+      const metadata = this.metadata.get(name);
+      if (predicate(item, name, metadata)) {
+        return { name, item, metadata };
+      }
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Generic cache for MCP operations
+ */
+export class MCPCache<K, V> {
+  private cache = new Map<K, { value: V; timestamp: number; ttl?: number }>();
+  private defaultTTL: number;
+  
+  constructor(defaultTTL = 5 * 60 * 1000) { // 5 minutes default
+    this.defaultTTL = defaultTTL;
+  }
+  
+  /**
+   * Sets a value in the cache
+   */
+  set(key: K, value: V, ttl?: number): void {
+    const entry = {
+      value,
+      timestamp: Date.now(),
+      ttl: ttl ?? this.defaultTTL
+    };
+    this.cache.set(key, entry);
+  }
+  
+  /**
+   * Gets a value from the cache
+   */
+  get(key: K): V | undefined {
+    const entry = this.cache.get(key);
+    if (!entry) return undefined;
+    
+    // Check if expired
+    if (entry.ttl && Date.now() - entry.timestamp > entry.ttl) {
+      this.cache.delete(key);
+      return undefined;
+    }
+    
+    return entry.value;
+  }
+  
+  /**
+   * Checks if a key exists in the cache
+   */
+  has(key: K): boolean {
+    return this.get(key) !== undefined;
+  }
+  
+  /**
+   * Deletes a value from the cache
+   */
+  delete(key: K): boolean {
+    return this.cache.delete(key);
+  }
+  
+  /**
+   * Clears all values from the cache
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+  
+  /**
+   * Gets the number of cached items
+   */
+  size(): number {
+    return this.cache.size;
+  }
+  
+  /**
+   * Cleans up expired entries
+   */
+  cleanup(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cache) {
+      if (entry.ttl && now - entry.timestamp > entry.ttl) {
+        this.cache.delete(key);
+      }
+    }
+  }
+  
+  /**
+   * Gets all keys
+   */
+  keys(): K[] {
+    return Array.from(this.cache.keys());
+  }
+  
+  /**
+   * Gets all values (non-expired)
+   */
+  values(): V[] {
+    const values: V[] = [];
+    for (const key of this.cache.keys()) {
+      const value = this.get(key);
+      if (value !== undefined) {
+        values.push(value);
+      }
+    }
+    return values;
+  }
+}
+
+/**
+ * Generic queue for MCP operations
+ */
+export class MCPQueue<T> {
+  private queue: T[] = [];
+  private processing = false;
+  private processor?: (item: T) => Promise<void>;
+  
+  constructor(processor?: (item: T) => Promise<void>) {
+    this.processor = processor;
+  }
+  
+  /**
+   * Adds an item to the queue
+   */
+  enqueue(item: T): void {
+    this.queue.push(item);
+    if (this.processor && !this.processing) {
+      this.process();
+    }
+  }
+  
+  /**
+   * Removes and returns the first item from the queue
+   */
+  dequeue(): T | undefined {
+    return this.queue.shift();
+  }
+  
+  /**
+   * Peeks at the first item without removing it
+   */
+  peek(): T | undefined {
+    return this.queue[0];
+  }
+  
+  /**
+   * Checks if the queue is empty
+   */
+  isEmpty(): boolean {
+    return this.queue.length === 0;
+  }
+  
+  /**
+   * Gets the number of items in the queue
+   */
+  size(): number {
+    return this.queue.length;
+  }
+  
+  /**
+   * Clears all items from the queue
+   */
+  clear(): void {
+    this.queue = [];
+  }
+  
+  /**
+   * Processes all items in the queue
+   */
+  private async process(): Promise<void> {
+    if (this.processing || !this.processor) return;
+    
+    this.processing = true;
+    
+    try {
+      while (!this.isEmpty()) {
+        const item = this.dequeue();
+        if (item) {
+          await this.processor(item);
+        }
+      }
+    } finally {
+      this.processing = false;
+    }
+  }
+  
+  /**
+   * Sets a new processor function
+   */
+  setProcessor(processor: (item: T) => Promise<void>): void {
+    this.processor = processor;
+    if (!this.processing && !this.isEmpty()) {
+      this.process();
+    }
+  }
+  
+  /**
+   * Converts the queue to an array
+   */
+  toArray(): T[] {
+    return [...this.queue];
+  }
+}
+
+// ================================================================
+// GENERIC BUILDERS
+// ================================================================
+
+/**
+ * Generic builder for MCP tools
+ */
+export class MCPToolBuilder<
+  TName extends string = string,
+  TInput = unknown,
+  TOutput = unknown,
+  TContext extends MCPContext = MCPContext
+> {
+  private tool: Partial<TypedMCPTool<TName, TInput, TOutput, TContext>> = {};
+  
+  /**
+   * Sets the tool name
+   */
+  name<NewName extends string>(name: NewName): MCPToolBuilder<NewName, TInput, TOutput, TContext> {
+    this.tool.name = name as any;
+    return this as any;
+  }
+  
+  /**
+   * Sets the tool description
+   */
+  description(description: string): this {
+    this.tool.description = description;
+    return this;
+  }
+  
+  /**
+   * Sets the input schema
+   */
+  inputSchema(schema: JSONSchema): this {
+    this.tool.inputSchema = schema;
+    return this;
+  }
+  
+  /**
+   * Sets the handler function
+   */
+  handler(handler: MCPHandler<TInput, TOutput, TContext>): this {
+    this.tool.handler = handler;
+    return this;
+  }
+  
+  /**
+   * Builds the tool
+   */
+  build(): TypedMCPTool<TName, TInput, TOutput, TContext> {
+    if (!this.tool.name) {
+      throw createMCPError(MCPErrorCode.VALIDATION_ERROR, 'Tool name is required');
+    }
+    if (!this.tool.description) {
+      throw createMCPError(MCPErrorCode.VALIDATION_ERROR, 'Tool description is required');
+    }
+    if (!this.tool.inputSchema) {
+      throw createMCPError(MCPErrorCode.VALIDATION_ERROR, 'Tool input schema is required');
+    }
+    if (!this.tool.handler) {
+      throw createMCPError(MCPErrorCode.VALIDATION_ERROR, 'Tool handler is required');
+    }
+    
+    return this.tool as TypedMCPTool<TName, TInput, TOutput, TContext>;
+  }
+}
+
+/**
+ * Generic builder for MCP prompts
+ */
+export class MCPPromptBuilder<
+  TName extends string = string,
+  TArgs extends Record<string, any> = Record<string, any>
+> {
+  private prompt: Partial<TypedMCPPrompt<TName, TArgs>> = {};
+  
+  /**
+   * Sets the prompt name
+   */
+  name<NewName extends string>(name: NewName): MCPPromptBuilder<NewName, TArgs> {
+    this.prompt.name = name as any;
+    return this as any;
+  }
+  
+  /**
+   * Sets the prompt description
+   */
+  description(description: string): this {
+    this.prompt.description = description;
+    return this;
+  }
+  
+  /**
+   * Adds an argument
+   */
+  argument<K extends keyof TArgs>(name: K, description?: string, required?: boolean): this {
+    if (!this.prompt.arguments) {
+      this.prompt.arguments = [];
+    }
+    
+    this.prompt.arguments.push({
+      name,
+      description,
+      required
+    });
+    
+    return this;
+  }
+  
+  /**
+   * Builds the prompt
+   */
+  build(): TypedMCPPrompt<TName, TArgs> {
+    if (!this.prompt.name) {
+      throw createMCPError(MCPErrorCode.VALIDATION_ERROR, 'Prompt name is required');
+    }
+    
+    return this.prompt as TypedMCPPrompt<TName, TArgs>;
+  }
+}
+
+/**
+ * Generic builder for MCP resources
+ */
+export class MCPResourceBuilder<
+  TUri extends string = string,
+  TContent = unknown
+> {
+  private resource: Partial<TypedMCPResource<TUri, TContent>> = {};
+  
+  /**
+   * Sets the resource URI
+   */
+  uri<NewUri extends string>(uri: NewUri): MCPResourceBuilder<NewUri, TContent> {
+    this.resource.uri = uri as any;
+    return this as any;
+  }
+  
+  /**
+   * Sets the resource name
+   */
+  name(name: string): this {
+    this.resource.name = name;
+    return this;
+  }
+  
+  /**
+   * Sets the resource description
+   */
+  description(description: string): this {
+    this.resource.description = description;
+    return this;
+  }
+  
+  /**
+   * Sets the resource MIME type
+   */
+  mimeType(mimeType: string): this {
+    this.resource.mimeType = mimeType;
+    return this;
+  }
+  
+  /**
+   * Sets the resource content
+   */
+  content(content: TContent): this {
+    this.resource.content = content;
+    return this;
+  }
+  
+  /**
+   * Builds the resource
+   */
+  build(): TypedMCPResource<TUri, TContent> {
+    if (!this.resource.uri) {
+      throw createMCPError(MCPErrorCode.VALIDATION_ERROR, 'Resource URI is required');
+    }
+    if (!this.resource.name) {
+      throw createMCPError(MCPErrorCode.VALIDATION_ERROR, 'Resource name is required');
+    }
+    
+    return this.resource as TypedMCPResource<TUri, TContent>;
+  }
+}
+
+// ================================================================
+// GENERIC MIDDLEWARE
+// ================================================================
+
+/**
+ * Generic middleware function type
+ */
+export type MCPMiddleware<TContext extends MCPContext = MCPContext> = (
+  context: TContext,
+  next: () => Promise<void>
+) => Promise<void>;
+
+/**
+ * Generic middleware chain
+ */
+export class MCPMiddlewareChain<TContext extends MCPContext = MCPContext> {
+  private middlewares: MCPMiddleware<TContext>[] = [];
+  
+  /**
+   * Adds middleware to the chain
+   */
+  use(middleware: MCPMiddleware<TContext>): this {
+    this.middlewares.push(middleware);
+    return this;
+  }
+  
+  /**
+   * Executes the middleware chain
+   */
+  async execute(context: TContext, final?: () => Promise<void>): Promise<void> {
+    let index = 0;
+    
+    const next = async (): Promise<void> => {
+      if (index >= this.middlewares.length) {
+        if (final) {
+          await final();
+        }
+        return;
+      }
+      
+      const middleware = this.middlewares[index++];
+      await middleware(context, next);
+    };
+    
+    await next();
+  }
+  
+  /**
+   * Gets the number of middlewares
+   */
+  size(): number {
+    return this.middlewares.length;
+  }
+  
+  /**
+   * Clears all middlewares
+   */
+  clear(): void {
+    this.middlewares = [];
+  }
+}
+
+// ================================================================
+// GENERIC UTILITIES
+// ================================================================
+
+/**
+ * Creates a type-safe MCP tool
+ */
+export function createTypedTool<
+  TName extends string,
+  TInput = unknown,
+  TOutput = unknown,
+  TContext extends MCPContext = MCPContext
+>(name: TName): MCPToolBuilder<TName, TInput, TOutput, TContext> {
+  return new MCPToolBuilder<TName, TInput, TOutput, TContext>().name(name);
+}
+
+/**
+ * Creates a type-safe MCP prompt
+ */
+export function createTypedPrompt<
+  TName extends string,
+  TArgs extends Record<string, any> = Record<string, any>
+>(name: TName): MCPPromptBuilder<TName, TArgs> {
+  return new MCPPromptBuilder<TName, TArgs>().name(name);
+}
+
+/**
+ * Creates a type-safe MCP resource
+ */
+export function createTypedResource<
+  TUri extends string,
+  TContent = unknown
+>(uri: TUri): MCPResourceBuilder<TUri, TContent> {
+  return new MCPResourceBuilder<TUri, TContent>().uri(uri);
+}
+
+/**
+ * Creates a generic MCP registry
+ */
+export function createRegistry<T>(): MCPRegistry<T> {
+  return new MCPRegistry<T>();
+}
+
+/**
+ * Creates a generic MCP cache
+ */
+export function createCache<K, V>(defaultTTL?: number): MCPCache<K, V> {
+  return new MCPCache<K, V>(defaultTTL);
+}
+
+/**
+ * Creates a generic MCP queue
+ */
+export function createQueue<T>(processor?: (item: T) => Promise<void>): MCPQueue<T> {
+  return new MCPQueue<T>(processor);
+}
+
+/**
+ * Creates a generic middleware chain
+ */
+export function createMiddlewareChain<TContext extends MCPContext = MCPContext>(): MCPMiddlewareChain<TContext> {
+  return new MCPMiddlewareChain<TContext>();
+}
+
+/**
+ * Utility function to check if two types are equal
+ */
+export type TypeEquals<T, U> = T extends U ? U extends T ? true : false : false;
+
+/**
+ * Utility function to assert type equality at compile time
+ */
+export function assertTypeEquals<T, U>(): TypeEquals<T, U> {
+  return true as TypeEquals<T, U>;
+}
+
+/**
+ * Utility function to create a type-safe predicate
+ */
+export function createPredicate<T>(
+  predicate: (item: T) => boolean
+): (item: T) => boolean {
+  return predicate;
+}
+
+/**
+ * Utility function to create a type-safe mapper
+ */
+export function createMapper<T, U>(
+  mapper: (item: T) => U
+): (item: T) => U {
+  return mapper;
+}
+
+/**
+ * Utility function to create a type-safe comparator
+ */
+export function createComparator<T>(
+  comparator: (a: T, b: T) => number
+): (a: T, b: T) => number {
+  return comparator;
+}
+
+// ================================================================
+// EXPORT GENERICS SUITE
+// ================================================================
+
+/**
+ * Complete generics suite for MCP protocol
+ */
+export const MCPGenerics = {
+  // Classes
+  MCPRegistry,
+  MCPCache,
+  MCPQueue,
+  MCPToolBuilder,
+  MCPPromptBuilder,
+  MCPResourceBuilder,
+  MCPMiddlewareChain,
+  
+  // Factory functions
+  createTypedTool,
+  createTypedPrompt,
+  createTypedResource,
+  createRegistry,
+  createCache,
+  createQueue,
+  createMiddlewareChain,
+  
+  // Utility functions
+  assertTypeEquals,
+  createPredicate,
+  createMapper,
+  createComparator
+};
+
+export default MCPGenerics;

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -4,6 +4,12 @@ import { getErrorMessage } from '../utils/error-handler.js';
  * Export all MCP components for easy integration
  */
 
+// Core type definitions and utilities
+export * from './types.js';
+export * from './type-guards.js';
+export * from './serialization.js';
+export * from './generics.js';
+
 // Core MCP Server
 export { MCPServer, type IMCPServer } from './server.js';
 

--- a/src/mcp/serialization.ts
+++ b/src/mcp/serialization.ts
@@ -1,0 +1,848 @@
+/**
+ * Serialization utilities for MCP protocol messages
+ * Provides efficient serialization/deserialization with type safety and validation
+ */
+
+import {
+  JSONRPCMessage,
+  JSONRPCRequest,
+  JSONRPCResponse,
+  JSONRPCNotification,
+  MCPError,
+  MCPErrorCode,
+  MCPTool,
+  MCPToolResult,
+  MCPPrompt,
+  MCPResource,
+  MCPSession,
+  MCPEvent,
+  MCPContext,
+  MCPInitializeParams,
+  MCPInitializeResult,
+  MCPProtocolVersion,
+  MCPCapabilities,
+  MCPClientInfo,
+  MCPServerInfo,
+  MCPToolContent,
+  MCPPromptMessage,
+  MCPResourceContent
+} from './types.js';
+
+import {
+  isJSONRPCMessage,
+  isJSONRPCRequest,
+  isJSONRPCResponse,
+  isJSONRPCNotification,
+  isMCPError,
+  createMCPError,
+  safeParseJSONRPCMessage,
+  safeStringifyJSONRPCMessage,
+  validateJSONRPCMessage
+} from './type-guards.js';
+
+// ================================================================
+// SERIALIZATION OPTIONS
+// ================================================================
+
+/**
+ * Serialization options for customizing behavior
+ */
+export interface SerializationOptions {
+  /**
+   * Whether to include metadata in serialized output
+   */
+  includeMetadata?: boolean;
+  
+  /**
+   * Whether to compress large payloads
+   */
+  compress?: boolean;
+  
+  /**
+   * Maximum size limit for serialized messages (in bytes)
+   */
+  maxSize?: number;
+  
+  /**
+   * Whether to validate data before serialization
+   */
+  validate?: boolean;
+  
+  /**
+   * Whether to pretty-print JSON output
+   */
+  prettyPrint?: boolean;
+  
+  /**
+   * Custom replacer function for JSON.stringify
+   */
+  replacer?: (key: string, value: any) => any;
+  
+  /**
+   * Custom reviver function for JSON.parse
+   */
+  reviver?: (key: string, value: any) => any;
+  
+  /**
+   * Whether to include debug information
+   */
+  debug?: boolean;
+}
+
+/**
+ * Default serialization options
+ */
+export const DEFAULT_SERIALIZATION_OPTIONS: SerializationOptions = {
+  includeMetadata: true,
+  compress: false,
+  maxSize: 10 * 1024 * 1024, // 10MB
+  validate: true,
+  prettyPrint: false,
+  debug: false
+};
+
+// ================================================================
+// SERIALIZATION RESULTS
+// ================================================================
+
+/**
+ * Result of serialization operation
+ */
+export interface SerializationResult {
+  /**
+   * Serialized data
+   */
+  data: string;
+  
+  /**
+   * Size of serialized data in bytes
+   */
+  size: number;
+  
+  /**
+   * Whether compression was applied
+   */
+  compressed: boolean;
+  
+  /**
+   * Metadata about the serialization
+   */
+  metadata?: {
+    originalSize?: number;
+    compressionRatio?: number;
+    serializationTime?: number;
+    validationTime?: number;
+  };
+}
+
+/**
+ * Result of deserialization operation
+ */
+export interface DeserializationResult<T> {
+  /**
+   * Deserialized data
+   */
+  data: T;
+  
+  /**
+   * Whether data was compressed
+   */
+  compressed: boolean;
+  
+  /**
+   * Metadata about the deserialization
+   */
+  metadata?: {
+    deserializationTime?: number;
+    validationTime?: number;
+    dataSize?: number;
+  };
+}
+
+// ================================================================
+// COMPRESSION UTILITIES
+// ================================================================
+
+/**
+ * Simple compression using base64 encoding of gzipped data
+ * In a real implementation, you would use a proper compression library
+ */
+async function compress(data: string): Promise<string> {
+  // Placeholder for actual compression
+  // In production, use libraries like 'zlib' or 'pako'
+  return Buffer.from(data).toString('base64');
+}
+
+/**
+ * Decompression for base64 encoded data
+ */
+async function decompress(data: string): Promise<string> {
+  // Placeholder for actual decompression
+  return Buffer.from(data, 'base64').toString();
+}
+
+// ================================================================
+// CORE SERIALIZATION FUNCTIONS
+// ================================================================
+
+/**
+ * Serializes a JSON-RPC message with options
+ */
+export async function serializeMessage(
+  message: JSONRPCMessage,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<SerializationResult> {
+  const startTime = Date.now();
+  
+  try {
+    // Validate message if requested
+    if (options.validate) {
+      const validationStart = Date.now();
+      validateJSONRPCMessage(message);
+      const validationTime = Date.now() - validationStart;
+      
+      if (options.debug) {
+        console.debug(`Message validation took ${validationTime}ms`);
+      }
+    }
+    
+    // Prepare serialization options
+    const replacer = options.replacer || defaultReplacer;
+    const space = options.prettyPrint ? 2 : 0;
+    
+    // Serialize to JSON
+    const jsonData = JSON.stringify(message, replacer, space);
+    const originalSize = Buffer.byteLength(jsonData, 'utf8');
+    
+    // Check size limit
+    if (options.maxSize && originalSize > options.maxSize) {
+      throw createMCPError(
+        MCPErrorCode.VALIDATION_ERROR,
+        `Message size ${originalSize} exceeds maximum ${options.maxSize}`
+      );
+    }
+    
+    // Apply compression if requested and beneficial
+    let finalData = jsonData;
+    let compressed = false;
+    let compressionRatio = 1;
+    
+    if (options.compress && originalSize > 1024) { // Only compress if > 1KB
+      const compressedData = await compress(jsonData);
+      const compressedSize = Buffer.byteLength(compressedData, 'utf8');
+      
+      if (compressedSize < originalSize * 0.9) { // Only use if >10% reduction
+        finalData = compressedData;
+        compressed = true;
+        compressionRatio = originalSize / compressedSize;
+      }
+    }
+    
+    const finalSize = Buffer.byteLength(finalData, 'utf8');
+    const serializationTime = Date.now() - startTime;
+    
+    const result: SerializationResult = {
+      data: finalData,
+      size: finalSize,
+      compressed
+    };
+    
+    if (options.includeMetadata) {
+      result.metadata = {
+        originalSize,
+        compressionRatio,
+        serializationTime
+      };
+    }
+    
+    return result;
+    
+  } catch (error) {
+    if (isMCPError(error)) {
+      throw error;
+    }
+    
+    throw createMCPError(
+      MCPErrorCode.INTERNAL_ERROR,
+      'Serialization failed',
+      { originalError: error }
+    );
+  }
+}
+
+/**
+ * Deserializes a JSON-RPC message with options
+ */
+export async function deserializeMessage<T extends JSONRPCMessage = JSONRPCMessage>(
+  data: string,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<DeserializationResult<T>> {
+  const startTime = Date.now();
+  
+  try {
+    // Detect if data is compressed (simple heuristic)
+    const isCompressed = !data.startsWith('{') && !data.startsWith('[');
+    
+    // Decompress if needed
+    let jsonData = data;
+    if (isCompressed) {
+      jsonData = await decompress(data);
+    }
+    
+    // Parse JSON
+    const reviver = options.reviver || defaultReviver;
+    const parsed = JSON.parse(jsonData, reviver);
+    
+    // Validate if requested
+    if (options.validate) {
+      const validationStart = Date.now();
+      validateJSONRPCMessage(parsed);
+      const validationTime = Date.now() - validationStart;
+      
+      if (options.debug) {
+        console.debug(`Message validation took ${validationTime}ms`);
+      }
+    }
+    
+    const deserializationTime = Date.now() - startTime;
+    const dataSize = Buffer.byteLength(jsonData, 'utf8');
+    
+    const result: DeserializationResult<T> = {
+      data: parsed as T,
+      compressed: isCompressed
+    };
+    
+    if (options.includeMetadata) {
+      result.metadata = {
+        deserializationTime,
+        dataSize
+      };
+    }
+    
+    return result;
+    
+  } catch (error) {
+    if (isMCPError(error)) {
+      throw error;
+    }
+    
+    throw createMCPError(
+      MCPErrorCode.PARSE_ERROR,
+      'Deserialization failed',
+      { originalError: error }
+    );
+  }
+}
+
+// ================================================================
+// SPECIALIZED SERIALIZATION FUNCTIONS
+// ================================================================
+
+/**
+ * Serializes an MCP tool definition
+ */
+export async function serializeTool(
+  tool: MCPTool,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<SerializationResult> {
+  // Remove the handler function for serialization
+  const { handler, ...toolDefinition } = tool;
+  
+  return serializeMessage(toolDefinition as any, options);
+}
+
+/**
+ * Serializes an MCP tool result
+ */
+export async function serializeToolResult(
+  result: MCPToolResult,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<SerializationResult> {
+  // Handle binary content specially
+  const processedResult = {
+    ...result,
+    content: result.content.map(content => ({
+      ...content,
+      blob: content.blob ? Array.from(content.blob) : undefined
+    }))
+  };
+  
+  return serializeMessage(processedResult as any, options);
+}
+
+/**
+ * Deserializes an MCP tool result
+ */
+export async function deserializeToolResult(
+  data: string,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<DeserializationResult<MCPToolResult>> {
+  const result = await deserializeMessage(data, options);
+  
+  // Restore binary content
+  const processedResult = {
+    ...result.data,
+    content: (result.data as any).content.map((content: any) => ({
+      ...content,
+      blob: content.blob ? new Uint8Array(content.blob) : undefined
+    }))
+  };
+  
+  return {
+    ...result,
+    data: processedResult as MCPToolResult
+  };
+}
+
+/**
+ * Serializes an MCP session
+ */
+export async function serializeSession(
+  session: MCPSession,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<SerializationResult> {
+  // Remove non-serializable properties
+  const { transport, ...sessionData } = session;
+  
+  const processedSession = {
+    ...sessionData,
+    transportType: transport.type,
+    createdAt: session.createdAt.toISOString(),
+    lastActivity: session.lastActivity.toISOString()
+  };
+  
+  return serializeMessage(processedSession as any, options);
+}
+
+/**
+ * Deserializes an MCP session (partial - transport needs to be restored)
+ */
+export async function deserializeSession(
+  data: string,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<DeserializationResult<Partial<MCPSession>>> {
+  const result = await deserializeMessage(data, options);
+  
+  // Restore Date objects
+  const processedSession = {
+    ...result.data,
+    createdAt: new Date((result.data as any).createdAt),
+    lastActivity: new Date((result.data as any).lastActivity)
+  };
+  
+  return {
+    ...result,
+    data: processedSession as Partial<MCPSession>
+  };
+}
+
+/**
+ * Serializes an MCP event
+ */
+export async function serializeEvent(
+  event: MCPEvent,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<SerializationResult> {
+  const processedEvent = {
+    ...event,
+    timestamp: event.timestamp.toISOString()
+  };
+  
+  return serializeMessage(processedEvent as any, options);
+}
+
+/**
+ * Deserializes an MCP event
+ */
+export async function deserializeEvent(
+  data: string,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<DeserializationResult<MCPEvent>> {
+  const result = await deserializeMessage(data, options);
+  
+  // Restore Date object
+  const processedEvent = {
+    ...result.data,
+    timestamp: new Date((result.data as any).timestamp)
+  };
+  
+  return {
+    ...result,
+    data: processedEvent as MCPEvent
+  };
+}
+
+// ================================================================
+// BATCH SERIALIZATION
+// ================================================================
+
+/**
+ * Serializes multiple messages in a batch
+ */
+export async function serializeBatch(
+  messages: JSONRPCMessage[],
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<SerializationResult> {
+  const startTime = Date.now();
+  
+  try {
+    // Validate all messages if requested
+    if (options.validate) {
+      for (const message of messages) {
+        validateJSONRPCMessage(message);
+      }
+    }
+    
+    // Serialize the batch
+    const batchData = JSON.stringify(messages, options.replacer, options.prettyPrint ? 2 : 0);
+    const originalSize = Buffer.byteLength(batchData, 'utf8');
+    
+    // Check size limit
+    if (options.maxSize && originalSize > options.maxSize) {
+      throw createMCPError(
+        MCPErrorCode.VALIDATION_ERROR,
+        `Batch size ${originalSize} exceeds maximum ${options.maxSize}`
+      );
+    }
+    
+    // Apply compression if requested
+    let finalData = batchData;
+    let compressed = false;
+    let compressionRatio = 1;
+    
+    if (options.compress && originalSize > 1024) {
+      const compressedData = await compress(batchData);
+      const compressedSize = Buffer.byteLength(compressedData, 'utf8');
+      
+      if (compressedSize < originalSize * 0.9) {
+        finalData = compressedData;
+        compressed = true;
+        compressionRatio = originalSize / compressedSize;
+      }
+    }
+    
+    const finalSize = Buffer.byteLength(finalData, 'utf8');
+    const serializationTime = Date.now() - startTime;
+    
+    const result: SerializationResult = {
+      data: finalData,
+      size: finalSize,
+      compressed
+    };
+    
+    if (options.includeMetadata) {
+      result.metadata = {
+        originalSize,
+        compressionRatio,
+        serializationTime
+      };
+    }
+    
+    return result;
+    
+  } catch (error) {
+    if (isMCPError(error)) {
+      throw error;
+    }
+    
+    throw createMCPError(
+      MCPErrorCode.INTERNAL_ERROR,
+      'Batch serialization failed',
+      { originalError: error }
+    );
+  }
+}
+
+/**
+ * Deserializes a batch of messages
+ */
+export async function deserializeBatch(
+  data: string,
+  options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS
+): Promise<DeserializationResult<JSONRPCMessage[]>> {
+  const startTime = Date.now();
+  
+  try {
+    // Detect if data is compressed
+    const isCompressed = !data.startsWith('[') && !data.startsWith('{');
+    
+    // Decompress if needed
+    let jsonData = data;
+    if (isCompressed) {
+      jsonData = await decompress(data);
+    }
+    
+    // Parse JSON
+    const parsed = JSON.parse(jsonData, options.reviver);
+    
+    // Validate that it's an array
+    if (!Array.isArray(parsed)) {
+      throw createMCPError(
+        MCPErrorCode.INVALID_REQUEST,
+        'Batch must be an array of messages'
+      );
+    }
+    
+    // Validate each message if requested
+    if (options.validate) {
+      for (const message of parsed) {
+        validateJSONRPCMessage(message);
+      }
+    }
+    
+    const deserializationTime = Date.now() - startTime;
+    const dataSize = Buffer.byteLength(jsonData, 'utf8');
+    
+    const result: DeserializationResult<JSONRPCMessage[]> = {
+      data: parsed,
+      compressed: isCompressed
+    };
+    
+    if (options.includeMetadata) {
+      result.metadata = {
+        deserializationTime,
+        dataSize
+      };
+    }
+    
+    return result;
+    
+  } catch (error) {
+    if (isMCPError(error)) {
+      throw error;
+    }
+    
+    throw createMCPError(
+      MCPErrorCode.PARSE_ERROR,
+      'Batch deserialization failed',
+      { originalError: error }
+    );
+  }
+}
+
+// ================================================================
+// STREAMING SERIALIZATION
+// ================================================================
+
+/**
+ * Streaming serializer for large datasets
+ */
+export class StreamingSerializer {
+  private options: SerializationOptions;
+  private buffer: string[] = [];
+  private size = 0;
+  
+  constructor(options: SerializationOptions = DEFAULT_SERIALIZATION_OPTIONS) {
+    this.options = options;
+  }
+  
+  /**
+   * Adds a message to the stream
+   */
+  async add(message: JSONRPCMessage): Promise<void> {
+    if (this.options.validate) {
+      validateJSONRPCMessage(message);
+    }
+    
+    const serialized = JSON.stringify(message, this.options.replacer);
+    this.buffer.push(serialized);
+    this.size += Buffer.byteLength(serialized, 'utf8');
+    
+    // Check size limit
+    if (this.options.maxSize && this.size > this.options.maxSize) {
+      throw createMCPError(
+        MCPErrorCode.VALIDATION_ERROR,
+        `Stream size ${this.size} exceeds maximum ${this.options.maxSize}`
+      );
+    }
+  }
+  
+  /**
+   * Finalizes the stream and returns serialized data
+   */
+  async finalize(): Promise<SerializationResult> {
+    const arrayData = '[' + this.buffer.join(',') + ']';
+    const originalSize = Buffer.byteLength(arrayData, 'utf8');
+    
+    let finalData = arrayData;
+    let compressed = false;
+    let compressionRatio = 1;
+    
+    if (this.options.compress && originalSize > 1024) {
+      const compressedData = await compress(arrayData);
+      const compressedSize = Buffer.byteLength(compressedData, 'utf8');
+      
+      if (compressedSize < originalSize * 0.9) {
+        finalData = compressedData;
+        compressed = true;
+        compressionRatio = originalSize / compressedSize;
+      }
+    }
+    
+    const finalSize = Buffer.byteLength(finalData, 'utf8');
+    
+    return {
+      data: finalData,
+      size: finalSize,
+      compressed,
+      metadata: this.options.includeMetadata ? {
+        originalSize,
+        compressionRatio
+      } : undefined
+    };
+  }
+  
+  /**
+   * Clears the stream buffer
+   */
+  clear(): void {
+    this.buffer = [];
+    this.size = 0;
+  }
+}
+
+// ================================================================
+// DEFAULT REPLACER/REVIVER FUNCTIONS
+// ================================================================
+
+/**
+ * Default replacer function for JSON.stringify
+ */
+function defaultReplacer(key: string, value: any): any {
+  // Handle Date objects
+  if (value instanceof Date) {
+    return { __type: 'Date', __value: value.toISOString() };
+  }
+  
+  // Handle RegExp objects
+  if (value instanceof RegExp) {
+    return { __type: 'RegExp', __value: value.toString() };
+  }
+  
+  // Handle Uint8Array
+  if (value instanceof Uint8Array) {
+    return { __type: 'Uint8Array', __value: Array.from(value) };
+  }
+  
+  // Handle functions (exclude them)
+  if (typeof value === 'function') {
+    return undefined;
+  }
+  
+  // Handle undefined
+  if (value === undefined) {
+    return { __type: 'undefined' };
+  }
+  
+  // Handle BigInt
+  if (typeof value === 'bigint') {
+    return { __type: 'BigInt', __value: value.toString() };
+  }
+  
+  return value;
+}
+
+/**
+ * Default reviver function for JSON.parse
+ */
+function defaultReviver(key: string, value: any): any {
+  // Handle special type objects
+  if (typeof value === 'object' && value !== null && '__type' in value) {
+    switch (value.__type) {
+      case 'Date':
+        return new Date(value.__value);
+      case 'RegExp':
+        const match = value.__value.match(/^\/(.+)\/([gimuy]*)$/);
+        return match ? new RegExp(match[1], match[2]) : new RegExp(value.__value);
+      case 'Uint8Array':
+        return new Uint8Array(value.__value);
+      case 'undefined':
+        return undefined;
+      case 'BigInt':
+        return BigInt(value.__value);
+    }
+  }
+  
+  return value;
+}
+
+// ================================================================
+// UTILITY FUNCTIONS
+// ================================================================
+
+/**
+ * Calculates the size of a serialized object
+ */
+export function calculateSize(obj: any): number {
+  return Buffer.byteLength(JSON.stringify(obj), 'utf8');
+}
+
+/**
+ * Checks if compression would be beneficial
+ */
+export function shouldCompress(data: string, threshold = 1024): boolean {
+  return Buffer.byteLength(data, 'utf8') > threshold;
+}
+
+/**
+ * Validates serialization options
+ */
+export function validateSerializationOptions(options: SerializationOptions): void {
+  if (options.maxSize && options.maxSize < 0) {
+    throw createMCPError(
+      MCPErrorCode.VALIDATION_ERROR,
+      'maxSize must be positive'
+    );
+  }
+  
+  if (options.replacer && typeof options.replacer !== 'function') {
+    throw createMCPError(
+      MCPErrorCode.VALIDATION_ERROR,
+      'replacer must be a function'
+    );
+  }
+  
+  if (options.reviver && typeof options.reviver !== 'function') {
+    throw createMCPError(
+      MCPErrorCode.VALIDATION_ERROR,
+      'reviver must be a function'
+    );
+  }
+}
+
+// ================================================================
+// EXPORT SERIALIZATION SUITE
+// ================================================================
+
+/**
+ * Complete serialization suite for MCP protocol
+ */
+export const MCPSerialization = {
+  // Core functions
+  serializeMessage,
+  deserializeMessage,
+  serializeBatch,
+  deserializeBatch,
+  
+  // Specialized functions
+  serializeTool,
+  serializeToolResult,
+  deserializeToolResult,
+  serializeSession,
+  deserializeSession,
+  serializeEvent,
+  deserializeEvent,
+  
+  // Streaming
+  StreamingSerializer,
+  
+  // Utilities
+  calculateSize,
+  shouldCompress,
+  validateSerializationOptions,
+  
+  // Constants
+  DEFAULT_SERIALIZATION_OPTIONS
+};
+
+export default MCPSerialization;

--- a/src/mcp/type-guards.ts
+++ b/src/mcp/type-guards.ts
@@ -1,0 +1,907 @@
+/**
+ * Type guards and validation utilities for MCP protocol
+ * Provides runtime type checking and validation for MCP messages and data structures
+ */
+
+import {
+  JSONRPCMessage,
+  JSONRPCRequest,
+  JSONRPCResponse,
+  JSONRPCNotification,
+  MCPError,
+  MCPErrorCode,
+  MCPProtocolVersion,
+  MCPCapabilities,
+  MCPTool,
+  MCPToolResult,
+  MCPToolContent,
+  MCPPrompt,
+  MCPPromptMessage,
+  MCPResource,
+  MCPResourceContent,
+  MCPInitializeParams,
+  MCPInitializeResult,
+  MCPContext,
+  MCPSession,
+  MCPLogLevel,
+  MCPTransportType,
+  MCPSessionState,
+  MCPAuthMethod,
+  JSONSchema,
+  MCPClientCapabilities,
+  MCPServerCapabilities,
+  MCPClientInfo,
+  MCPServerInfo,
+  MCPEvent,
+  MCPEventType
+} from './types.js';
+
+// ================================================================
+// BASIC TYPE GUARDS
+// ================================================================
+
+/**
+ * Checks if value is a string
+ */
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/**
+ * Checks if value is a number
+ */
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !isNaN(value);
+}
+
+/**
+ * Checks if value is a boolean
+ */
+export function isBoolean(value: unknown): value is boolean {
+  return typeof value === 'boolean';
+}
+
+/**
+ * Checks if value is an object (not null or array)
+ */
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Checks if value is an array
+ */
+export function isArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
+/**
+ * Checks if value is null
+ */
+export function isNull(value: unknown): value is null {
+  return value === null;
+}
+
+/**
+ * Checks if value is undefined
+ */
+export function isUndefined(value: unknown): value is undefined {
+  return value === undefined;
+}
+
+// ================================================================
+// JSON-RPC TYPE GUARDS
+// ================================================================
+
+/**
+ * Validates JSON-RPC 2.0 base structure
+ */
+export function isJSONRPCBase(value: unknown): value is { jsonrpc: '2.0' } {
+  return isObject(value) && value.jsonrpc === '2.0';
+}
+
+/**
+ * Type guard for JSON-RPC Request
+ */
+export function isJSONRPCRequest(value: unknown): value is JSONRPCRequest {
+  return (
+    isJSONRPCBase(value) &&
+    ('id' in value && (isString(value.id) || isNumber(value.id))) &&
+    ('method' in value && isString(value.method))
+  );
+}
+
+/**
+ * Type guard for JSON-RPC Response
+ */
+export function isJSONRPCResponse(value: unknown): value is JSONRPCResponse {
+  return (
+    isJSONRPCBase(value) &&
+    ('id' in value && (isString(value.id) || isNumber(value.id))) &&
+    (('result' in value) || ('error' in value && isMCPError(value.error)))
+  );
+}
+
+/**
+ * Type guard for JSON-RPC Notification
+ */
+export function isJSONRPCNotification(value: unknown): value is JSONRPCNotification {
+  return (
+    isJSONRPCBase(value) &&
+    ('method' in value && isString(value.method)) &&
+    !('id' in value)
+  );
+}
+
+/**
+ * Type guard for any JSON-RPC message
+ */
+export function isJSONRPCMessage(value: unknown): value is JSONRPCMessage {
+  return (
+    isJSONRPCRequest(value) ||
+    isJSONRPCResponse(value) ||
+    isJSONRPCNotification(value)
+  );
+}
+
+// ================================================================
+// MCP ERROR TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Error
+ */
+export function isMCPError(value: unknown): value is MCPError {
+  return (
+    isObject(value) &&
+    'code' in value &&
+    isNumber(value.code) &&
+    'message' in value &&
+    isString(value.message)
+  );
+}
+
+/**
+ * Validates MCP Error Code
+ */
+export function isMCPErrorCode(value: unknown): value is MCPErrorCode {
+  return isNumber(value) && Object.values(MCPErrorCode).includes(value);
+}
+
+/**
+ * Creates a validated MCP Error
+ */
+export function createMCPError(
+  code: MCPErrorCode,
+  message: string,
+  data?: unknown
+): MCPError {
+  if (!isMCPErrorCode(code)) {
+    throw new Error(`Invalid MCP error code: ${code}`);
+  }
+  if (!isString(message)) {
+    throw new Error('MCP error message must be a string');
+  }
+  return { code, message, data };
+}
+
+// ================================================================
+// MCP PROTOCOL VERSION TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Protocol Version
+ */
+export function isMCPProtocolVersion(value: unknown): value is MCPProtocolVersion {
+  return (
+    isObject(value) &&
+    'major' in value &&
+    isNumber(value.major) &&
+    'minor' in value &&
+    isNumber(value.minor) &&
+    'patch' in value &&
+    isNumber(value.patch)
+  );
+}
+
+/**
+ * Validates protocol version compatibility
+ */
+export function isProtocolVersionCompatible(
+  client: MCPProtocolVersion,
+  server: MCPProtocolVersion
+): boolean {
+  // Major versions must match
+  if (client.major !== server.major) {
+    return false;
+  }
+  
+  // Client minor version must be <= server minor version
+  if (client.minor > server.minor) {
+    return false;
+  }
+  
+  return true;
+}
+
+// ================================================================
+// MCP CAPABILITIES TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Client Capabilities
+ */
+export function isMCPClientCapabilities(value: unknown): value is MCPClientCapabilities {
+  if (!isObject(value)) return false;
+  
+  // Check optional properties
+  if ('sampling' in value && !isObject(value.sampling)) return false;
+  if ('logging' in value && !isObject(value.logging)) return false;
+  if ('tools' in value && !isObject(value.tools)) return false;
+  if ('prompts' in value && !isObject(value.prompts)) return false;
+  if ('resources' in value && !isObject(value.resources)) return false;
+  if ('experiments' in value && !isObject(value.experiments)) return false;
+  
+  return true;
+}
+
+/**
+ * Type guard for MCP Server Capabilities
+ */
+export function isMCPServerCapabilities(value: unknown): value is MCPServerCapabilities {
+  if (!isObject(value)) return false;
+  
+  // Check optional properties
+  if ('logging' in value && !isObject(value.logging)) return false;
+  if ('tools' in value && !isObject(value.tools)) return false;
+  if ('prompts' in value && !isObject(value.prompts)) return false;
+  if ('resources' in value && !isObject(value.resources)) return false;
+  if ('sampling' in value && !isObject(value.sampling)) return false;
+  if ('experiments' in value && !isObject(value.experiments)) return false;
+  
+  return true;
+}
+
+/**
+ * Type guard for MCP Capabilities (union type)
+ */
+export function isMCPCapabilities(value: unknown): value is MCPCapabilities {
+  return isMCPClientCapabilities(value) || isMCPServerCapabilities(value);
+}
+
+// ================================================================
+// MCP CLIENT/SERVER INFO TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Client Info
+ */
+export function isMCPClientInfo(value: unknown): value is MCPClientInfo {
+  return (
+    isObject(value) &&
+    'name' in value &&
+    isString(value.name) &&
+    'version' in value &&
+    isString(value.version)
+  );
+}
+
+/**
+ * Type guard for MCP Server Info
+ */
+export function isMCPServerInfo(value: unknown): value is MCPServerInfo {
+  return (
+    isObject(value) &&
+    'name' in value &&
+    isString(value.name) &&
+    'version' in value &&
+    isString(value.version)
+  );
+}
+
+// ================================================================
+// MCP INITIALIZATION TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Initialize Parameters
+ */
+export function isMCPInitializeParams(value: unknown): value is MCPInitializeParams {
+  return (
+    isObject(value) &&
+    'protocolVersion' in value &&
+    isMCPProtocolVersion(value.protocolVersion) &&
+    'capabilities' in value &&
+    isMCPClientCapabilities(value.capabilities) &&
+    'clientInfo' in value &&
+    isMCPClientInfo(value.clientInfo)
+  );
+}
+
+/**
+ * Type guard for MCP Initialize Result
+ */
+export function isMCPInitializeResult(value: unknown): value is MCPInitializeResult {
+  return (
+    isObject(value) &&
+    'protocolVersion' in value &&
+    isMCPProtocolVersion(value.protocolVersion) &&
+    'capabilities' in value &&
+    isMCPServerCapabilities(value.capabilities) &&
+    'serverInfo' in value &&
+    isMCPServerInfo(value.serverInfo)
+  );
+}
+
+// ================================================================
+// JSON SCHEMA TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for JSON Schema
+ */
+export function isJSONSchema(value: unknown): value is JSONSchema {
+  if (!isObject(value)) return false;
+  
+  // Must have a type
+  if (!('type' in value) || !isString(value.type)) return false;
+  
+  const validTypes = ['object', 'array', 'string', 'number', 'boolean', 'null'];
+  if (!validTypes.includes(value.type)) return false;
+  
+  // Validate optional properties
+  if ('properties' in value && !isObject(value.properties)) return false;
+  if ('items' in value && !isObject(value.items)) return false;
+  if ('required' in value && !isArray(value.required)) return false;
+  if ('description' in value && !isString(value.description)) return false;
+  if ('enum' in value && !isArray(value.enum)) return false;
+  if ('minimum' in value && !isNumber(value.minimum)) return false;
+  if ('maximum' in value && !isNumber(value.maximum)) return false;
+  if ('minLength' in value && !isNumber(value.minLength)) return false;
+  if ('maxLength' in value && !isNumber(value.maxLength)) return false;
+  if ('pattern' in value && !isString(value.pattern)) return false;
+  if ('format' in value && !isString(value.format)) return false;
+  
+  return true;
+}
+
+// ================================================================
+// MCP TOOL TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Tool Content
+ */
+export function isMCPToolContent(value: unknown): value is MCPToolContent {
+  if (!isObject(value)) return false;
+  
+  // Must have a type
+  if (!('type' in value) || !isString(value.type)) return false;
+  
+  const validTypes = ['text', 'image', 'resource', 'blob'];
+  if (!validTypes.includes(value.type)) return false;
+  
+  // Validate optional properties based on type
+  if ('text' in value && !isString(value.text)) return false;
+  if ('data' in value && !isString(value.data)) return false;
+  if ('blob' in value && !(value.blob instanceof Uint8Array)) return false;
+  if ('mimeType' in value && !isString(value.mimeType)) return false;
+  if ('name' in value && !isString(value.name)) return false;
+  if ('uri' in value && !isString(value.uri)) return false;
+  
+  return true;
+}
+
+/**
+ * Type guard for MCP Tool Result
+ */
+export function isMCPToolResult(value: unknown): value is MCPToolResult {
+  if (!isObject(value)) return false;
+  
+  // Must have content array
+  if (!('content' in value) || !isArray(value.content)) return false;
+  
+  // All content items must be valid
+  for (const item of value.content) {
+    if (!isMCPToolContent(item)) return false;
+  }
+  
+  // Validate optional properties
+  if ('isError' in value && !isBoolean(value.isError)) return false;
+  if ('meta' in value && !isObject(value.meta)) return false;
+  
+  return true;
+}
+
+/**
+ * Type guard for MCP Tool (without handler)
+ */
+export function isMCPToolDefinition(value: unknown): value is Omit<MCPTool, 'handler'> {
+  return (
+    isObject(value) &&
+    'name' in value &&
+    isString(value.name) &&
+    'description' in value &&
+    isString(value.description) &&
+    'inputSchema' in value &&
+    isJSONSchema(value.inputSchema)
+  );
+}
+
+/**
+ * Type guard for MCP Tool (with handler)
+ */
+export function isMCPTool(value: unknown): value is MCPTool {
+  return (
+    isMCPToolDefinition(value) &&
+    'handler' in value &&
+    typeof value.handler === 'function'
+  );
+}
+
+// ================================================================
+// MCP PROMPT TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Prompt Message
+ */
+export function isMCPPromptMessage(value: unknown): value is MCPPromptMessage {
+  if (!isObject(value)) return false;
+  
+  // Must have role and content
+  if (!('role' in value) || !isString(value.role)) return false;
+  if (!('content' in value) || !isObject(value.content)) return false;
+  
+  const validRoles = ['user', 'assistant', 'system'];
+  if (!validRoles.includes(value.role)) return false;
+  
+  // Validate content
+  const content = value.content;
+  if (!('type' in content) || !isString(content.type)) return false;
+  
+  const validContentTypes = ['text', 'image', 'resource'];
+  if (!validContentTypes.includes(content.type)) return false;
+  
+  // Validate optional content properties
+  if ('text' in content && !isString(content.text)) return false;
+  if ('data' in content && !isString(content.data)) return false;
+  if ('mimeType' in content && !isString(content.mimeType)) return false;
+  if ('uri' in content && !isString(content.uri)) return false;
+  
+  return true;
+}
+
+/**
+ * Type guard for MCP Prompt
+ */
+export function isMCPPrompt(value: unknown): value is MCPPrompt {
+  if (!isObject(value)) return false;
+  
+  // Must have name
+  if (!('name' in value) || !isString(value.name)) return false;
+  
+  // Validate optional properties
+  if ('description' in value && !isString(value.description)) return false;
+  if ('arguments' in value) {
+    if (!isArray(value.arguments)) return false;
+    for (const arg of value.arguments) {
+      if (!isObject(arg)) return false;
+      if (!('name' in arg) || !isString(arg.name)) return false;
+      if ('description' in arg && !isString(arg.description)) return false;
+      if ('required' in arg && !isBoolean(arg.required)) return false;
+    }
+  }
+  
+  return true;
+}
+
+// ================================================================
+// MCP RESOURCE TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Resource
+ */
+export function isMCPResource(value: unknown): value is MCPResource {
+  if (!isObject(value)) return false;
+  
+  // Must have uri and name
+  if (!('uri' in value) || !isString(value.uri)) return false;
+  if (!('name' in value) || !isString(value.name)) return false;
+  
+  // Validate optional properties
+  if ('description' in value && !isString(value.description)) return false;
+  if ('mimeType' in value && !isString(value.mimeType)) return false;
+  if ('annotations' in value && !isObject(value.annotations)) return false;
+  
+  return true;
+}
+
+/**
+ * Type guard for MCP Resource Content
+ */
+export function isMCPResourceContent(value: unknown): value is MCPResourceContent {
+  if (!isObject(value)) return false;
+  
+  // Must have uri
+  if (!('uri' in value) || !isString(value.uri)) return false;
+  
+  // Validate optional properties
+  if ('mimeType' in value && !isString(value.mimeType)) return false;
+  if ('text' in value && !isString(value.text)) return false;
+  if ('blob' in value && !(value.blob instanceof Uint8Array)) return false;
+  
+  return true;
+}
+
+// ================================================================
+// MCP CONTEXT TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Context
+ */
+export function isMCPContext(value: unknown): value is MCPContext {
+  if (!isObject(value)) return false;
+  
+  // Must have sessionId
+  if (!('sessionId' in value) || !isString(value.sessionId)) return false;
+  
+  // Validate optional properties
+  if ('requestId' in value && !isString(value.requestId) && !isNumber(value.requestId)) return false;
+  if ('agentId' in value && !isString(value.agentId)) return false;
+  if ('userId' in value && !isString(value.userId)) return false;
+  if ('permissions' in value && !isArray(value.permissions)) return false;
+  if ('metadata' in value && !isObject(value.metadata)) return false;
+  if ('protocolVersion' in value && !isMCPProtocolVersion(value.protocolVersion)) return false;
+  if ('capabilities' in value && !isMCPCapabilities(value.capabilities)) return false;
+  if ('timeout' in value && !isNumber(value.timeout)) return false;
+  
+  return true;
+}
+
+// ================================================================
+// MCP SESSION TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Session State
+ */
+export function isMCPSessionState(value: unknown): value is MCPSessionState {
+  const validStates = ['disconnected', 'connecting', 'connected', 'initializing', 'initialized', 'error'];
+  return isString(value) && validStates.includes(value);
+}
+
+/**
+ * Type guard for MCP Session
+ */
+export function isMCPSession(value: unknown): value is MCPSession {
+  if (!isObject(value)) return false;
+  
+  // Must have required properties
+  if (!('id' in value) || !isString(value.id)) return false;
+  if (!('state' in value) || !isMCPSessionState(value.state)) return false;
+  if (!('transport' in value) || !isObject(value.transport)) return false;
+  if (!('createdAt' in value) || !(value.createdAt instanceof Date)) return false;
+  if (!('lastActivity' in value) || !(value.lastActivity instanceof Date)) return false;
+  
+  // Validate optional properties
+  if ('clientInfo' in value && !isMCPClientInfo(value.clientInfo)) return false;
+  if ('serverInfo' in value && !isMCPServerInfo(value.serverInfo)) return false;
+  if ('protocolVersion' in value && !isMCPProtocolVersion(value.protocolVersion)) return false;
+  if ('clientCapabilities' in value && !isMCPClientCapabilities(value.clientCapabilities)) return false;
+  if ('serverCapabilities' in value && !isMCPServerCapabilities(value.serverCapabilities)) return false;
+  if ('metadata' in value && !isObject(value.metadata)) return false;
+  
+  return true;
+}
+
+// ================================================================
+// MCP LOG LEVEL TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Log Level
+ */
+export function isMCPLogLevel(value: unknown): value is MCPLogLevel {
+  const validLevels = ['debug', 'info', 'warn', 'error'];
+  return isString(value) && validLevels.includes(value);
+}
+
+// ================================================================
+// MCP TRANSPORT TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Transport Type
+ */
+export function isMCPTransportType(value: unknown): value is MCPTransportType {
+  const validTypes = ['stdio', 'http', 'websocket', 'sse'];
+  return isString(value) && validTypes.includes(value);
+}
+
+// ================================================================
+// MCP AUTH TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Auth Method
+ */
+export function isMCPAuthMethod(value: unknown): value is MCPAuthMethod {
+  const validMethods = ['none', 'token', 'basic', 'bearer', 'oauth', 'jwt', 'custom'];
+  return isString(value) && validMethods.includes(value);
+}
+
+// ================================================================
+// MCP EVENT TYPE GUARDS
+// ================================================================
+
+/**
+ * Type guard for MCP Event Type
+ */
+export function isMCPEventType(value: unknown): value is MCPEventType {
+  const validEventTypes = [
+    'session:created', 'session:initialized', 'session:closed', 'session:error',
+    'tool:called', 'tool:completed', 'tool:failed',
+    'prompt:called', 'prompt:completed', 'prompt:failed',
+    'resource:read', 'resource:subscribed', 'resource:unsubscribed', 'resource:updated',
+    'message:sent', 'message:received', 'error:occurred', 'metrics:collected'
+  ];
+  return isString(value) && validEventTypes.includes(value);
+}
+
+/**
+ * Type guard for MCP Event
+ */
+export function isMCPEvent(value: unknown): value is MCPEvent {
+  if (!isObject(value)) return false;
+  
+  // Must have required properties
+  if (!('type' in value) || !isMCPEventType(value.type)) return false;
+  if (!('sessionId' in value) || !isString(value.sessionId)) return false;
+  if (!('timestamp' in value) || !(value.timestamp instanceof Date)) return false;
+  if (!('data' in value)) return false;
+  
+  // Validate optional properties
+  if ('metadata' in value && !isObject(value.metadata)) return false;
+  
+  return true;
+}
+
+// ================================================================
+// VALIDATION UTILITIES
+// ================================================================
+
+/**
+ * Validates and normalizes a JSON-RPC message
+ */
+export function validateJSONRPCMessage(message: unknown): JSONRPCMessage {
+  if (!isJSONRPCMessage(message)) {
+    throw createMCPError(
+      MCPErrorCode.INVALID_REQUEST,
+      'Invalid JSON-RPC message format'
+    );
+  }
+  return message;
+}
+
+/**
+ * Validates MCP tool definition
+ */
+export function validateMCPTool(tool: unknown): MCPTool {
+  if (!isMCPTool(tool)) {
+    throw createMCPError(
+      MCPErrorCode.VALIDATION_ERROR,
+      'Invalid MCP tool definition'
+    );
+  }
+  return tool;
+}
+
+/**
+ * Validates MCP prompt definition
+ */
+export function validateMCPPrompt(prompt: unknown): MCPPrompt {
+  if (!isMCPPrompt(prompt)) {
+    throw createMCPError(
+      MCPErrorCode.VALIDATION_ERROR,
+      'Invalid MCP prompt definition'
+    );
+  }
+  return prompt;
+}
+
+/**
+ * Validates MCP resource definition
+ */
+export function validateMCPResource(resource: unknown): MCPResource {
+  if (!isMCPResource(resource)) {
+    throw createMCPError(
+      MCPErrorCode.VALIDATION_ERROR,
+      'Invalid MCP resource definition'
+    );
+  }
+  return resource;
+}
+
+/**
+ * Validates MCP context
+ */
+export function validateMCPContext(context: unknown): MCPContext {
+  if (!isMCPContext(context)) {
+    throw createMCPError(
+      MCPErrorCode.VALIDATION_ERROR,
+      'Invalid MCP context'
+    );
+  }
+  return context;
+}
+
+/**
+ * Validates MCP session
+ */
+export function validateMCPSession(session: unknown): MCPSession {
+  if (!isMCPSession(session)) {
+    throw createMCPError(
+      MCPErrorCode.VALIDATION_ERROR,
+      'Invalid MCP session'
+    );
+  }
+  return session;
+}
+
+/**
+ * Validates protocol version compatibility
+ */
+export function validateProtocolCompatibility(
+  client: MCPProtocolVersion,
+  server: MCPProtocolVersion
+): void {
+  if (!isProtocolVersionCompatible(client, server)) {
+    throw createMCPError(
+      MCPErrorCode.PROTOCOL_VERSION_MISMATCH,
+      `Protocol version mismatch: client ${client.major}.${client.minor}.${client.patch}, server ${server.major}.${server.minor}.${server.patch}`
+    );
+  }
+}
+
+// ================================================================
+// UTILITY FUNCTIONS
+// ================================================================
+
+/**
+ * Safely parses JSON and validates as JSON-RPC message
+ */
+export function safeParseJSONRPCMessage(json: string): JSONRPCMessage {
+  try {
+    const parsed = JSON.parse(json);
+    return validateJSONRPCMessage(parsed);
+  } catch (error) {
+    throw createMCPError(
+      MCPErrorCode.PARSE_ERROR,
+      'Failed to parse JSON-RPC message',
+      { originalError: error }
+    );
+  }
+}
+
+/**
+ * Safely stringifies JSON-RPC message
+ */
+export function safeStringifyJSONRPCMessage(message: JSONRPCMessage): string {
+  try {
+    return JSON.stringify(message);
+  } catch (error) {
+    throw createMCPError(
+      MCPErrorCode.INTERNAL_ERROR,
+      'Failed to stringify JSON-RPC message',
+      { originalError: error }
+    );
+  }
+}
+
+/**
+ * Creates a standard JSON-RPC error response
+ */
+export function createErrorResponse(
+  id: string | number,
+  error: MCPError
+): JSONRPCResponse {
+  return {
+    jsonrpc: '2.0',
+    id,
+    error
+  };
+}
+
+/**
+ * Creates a standard JSON-RPC success response
+ */
+export function createSuccessResponse(
+  id: string | number,
+  result: unknown
+): JSONRPCResponse {
+  return {
+    jsonrpc: '2.0',
+    id,
+    result
+  };
+}
+
+/**
+ * Creates a standard JSON-RPC notification
+ */
+export function createNotification(
+  method: string,
+  params?: unknown
+): JSONRPCNotification {
+  return {
+    jsonrpc: '2.0',
+    method,
+    params
+  };
+}
+
+/**
+ * Extracts error information from unknown error
+ */
+export function extractErrorInfo(error: unknown): { message: string; code: MCPErrorCode; data?: unknown } {
+  if (isMCPError(error)) {
+    return { message: error.message, code: error.code, data: error.data };
+  }
+  
+  if (error instanceof Error) {
+    return { message: error.message, code: MCPErrorCode.INTERNAL_ERROR, data: { stack: error.stack } };
+  }
+  
+  return { 
+    message: 'Unknown error occurred', 
+    code: MCPErrorCode.INTERNAL_ERROR, 
+    data: { originalError: error } 
+  };
+}
+
+// ================================================================
+// EXPORT DEFAULT VALIDATION SUITE
+// ================================================================
+
+/**
+ * Complete validation suite for MCP protocol
+ */
+export const MCPValidation = {
+  // Type guards
+  isJSONRPCMessage,
+  isJSONRPCRequest,
+  isJSONRPCResponse,
+  isJSONRPCNotification,
+  isMCPError,
+  isMCPProtocolVersion,
+  isMCPCapabilities,
+  isMCPTool,
+  isMCPPrompt,
+  isMCPResource,
+  isMCPContext,
+  isMCPSession,
+  isMCPEvent,
+  
+  // Validation functions
+  validateJSONRPCMessage,
+  validateMCPTool,
+  validateMCPPrompt,
+  validateMCPResource,
+  validateMCPContext,
+  validateMCPSession,
+  validateProtocolCompatibility,
+  
+  // Utility functions
+  safeParseJSONRPCMessage,
+  safeStringifyJSONRPCMessage,
+  createErrorResponse,
+  createSuccessResponse,
+  createNotification,
+  createMCPError,
+  extractErrorInfo
+};
+
+export default MCPValidation;

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,1089 @@
+/**
+ * Comprehensive TypeScript type definitions for MCP (Model Context Protocol) integration
+ * Provides type safety for all MCP protocol operations and Claude Flow extensions
+ */
+
+import { ILogger } from '../core/logger.js';
+import { EventEmitter } from 'node:events';
+
+// ================================================================
+// CORE MCP PROTOCOL TYPES
+// ================================================================
+
+/**
+ * MCP Protocol Version specification
+ */
+export interface MCPProtocolVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/**
+ * MCP Error codes as defined by the specification
+ */
+export enum MCPErrorCode {
+  PARSE_ERROR = -32700,
+  INVALID_REQUEST = -32600,
+  METHOD_NOT_FOUND = -32601,
+  INVALID_PARAMS = -32602,
+  INTERNAL_ERROR = -32603,
+  SERVER_ERROR = -32000,
+  TIMEOUT = -32001,
+  RATE_LIMITED = -32002,
+  AUTHENTICATION_FAILED = -32003,
+  AUTHORIZATION_FAILED = -32004,
+  RESOURCE_NOT_FOUND = -32005,
+  RESOURCE_CONFLICT = -32006,
+  VALIDATION_ERROR = -32007,
+  CAPABILITY_NOT_SUPPORTED = -32008,
+  PROTOCOL_VERSION_MISMATCH = -32009,
+  SESSION_EXPIRED = -32010,
+  RESOURCE_LOCKED = -32011,
+  QUOTA_EXCEEDED = -32012
+}
+
+/**
+ * MCP Error interface
+ */
+export interface MCPError {
+  code: MCPErrorCode;
+  message: string;
+  data?: unknown;
+}
+
+/**
+ * JSON-RPC 2.0 base interface
+ */
+export interface JSONRPCBase {
+  jsonrpc: '2.0';
+}
+
+/**
+ * JSON-RPC 2.0 Request
+ */
+export interface JSONRPCRequest extends JSONRPCBase {
+  id: string | number;
+  method: string;
+  params?: unknown;
+}
+
+/**
+ * JSON-RPC 2.0 Response
+ */
+export interface JSONRPCResponse extends JSONRPCBase {
+  id: string | number;
+  result?: unknown;
+  error?: MCPError;
+}
+
+/**
+ * JSON-RPC 2.0 Notification
+ */
+export interface JSONRPCNotification extends JSONRPCBase {
+  method: string;
+  params?: unknown;
+}
+
+/**
+ * Union type for all JSON-RPC message types
+ */
+export type JSONRPCMessage = JSONRPCRequest | JSONRPCResponse | JSONRPCNotification;
+
+// ================================================================
+// MCP CAPABILITIES AND FEATURES
+// ================================================================
+
+/**
+ * Client capabilities for MCP
+ */
+export interface MCPClientCapabilities {
+  sampling?: {
+    [key: string]: unknown;
+  };
+  logging?: {
+    level?: 'debug' | 'info' | 'warn' | 'error';
+  };
+  tools?: {
+    listChanged?: boolean;
+  };
+  prompts?: {
+    listChanged?: boolean;
+  };
+  resources?: {
+    listChanged?: boolean;
+    subscribe?: boolean;
+  };
+  experiments?: {
+    [key: string]: boolean;
+  };
+}
+
+/**
+ * Server capabilities for MCP
+ */
+export interface MCPServerCapabilities {
+  logging?: {
+    level?: 'debug' | 'info' | 'warn' | 'error';
+  };
+  tools?: {
+    listChanged?: boolean;
+  };
+  prompts?: {
+    listChanged?: boolean;
+  };
+  resources?: {
+    listChanged?: boolean;
+    subscribe?: boolean;
+  };
+  sampling?: {
+    [key: string]: unknown;
+  };
+  experiments?: {
+    [key: string]: boolean;
+  };
+}
+
+/**
+ * MCP Capabilities union type
+ */
+export type MCPCapabilities = MCPClientCapabilities | MCPServerCapabilities;
+
+// ================================================================
+// MCP INITIALIZATION
+// ================================================================
+
+/**
+ * Client info for MCP initialization
+ */
+export interface MCPClientInfo {
+  name: string;
+  version: string;
+}
+
+/**
+ * Server info for MCP initialization
+ */
+export interface MCPServerInfo {
+  name: string;
+  version: string;
+}
+
+/**
+ * MCP Initialize request parameters
+ */
+export interface MCPInitializeParams {
+  protocolVersion: MCPProtocolVersion;
+  capabilities: MCPClientCapabilities;
+  clientInfo: MCPClientInfo;
+}
+
+/**
+ * MCP Initialize response result
+ */
+export interface MCPInitializeResult {
+  protocolVersion: MCPProtocolVersion;
+  capabilities: MCPServerCapabilities;
+  serverInfo: MCPServerInfo;
+  instructions?: string;
+}
+
+// ================================================================
+// MCP TOOL SYSTEM
+// ================================================================
+
+/**
+ * JSON Schema for tool input validation
+ */
+export interface JSONSchema {
+  type: 'object' | 'array' | 'string' | 'number' | 'boolean' | 'null';
+  properties?: Record<string, JSONSchema>;
+  items?: JSONSchema;
+  required?: string[];
+  description?: string;
+  default?: unknown;
+  enum?: unknown[];
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  format?: string;
+  additionalProperties?: boolean | JSONSchema;
+  oneOf?: JSONSchema[];
+  anyOf?: JSONSchema[];
+  allOf?: JSONSchema[];
+  not?: JSONSchema;
+}
+
+/**
+ * MCP Tool definition
+ */
+export interface MCPTool {
+  name: string;
+  description: string;
+  inputSchema: JSONSchema;
+  handler: (input: unknown, context?: MCPContext) => Promise<unknown>;
+}
+
+/**
+ * MCP Tool result content types
+ */
+export interface MCPToolContent {
+  type: 'text' | 'image' | 'resource' | 'blob';
+  text?: string;
+  data?: string;
+  blob?: Uint8Array;
+  mimeType?: string;
+  name?: string;
+  uri?: string;
+}
+
+/**
+ * MCP Tool execution result
+ */
+export interface MCPToolResult {
+  content: MCPToolContent[];
+  isError?: boolean;
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * MCP Tool call parameters
+ */
+export interface MCPToolCallParams {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+/**
+ * MCP List Tools result
+ */
+export interface MCPListToolsResult {
+  tools: Array<{
+    name: string;
+    description: string;
+    inputSchema: JSONSchema;
+  }>;
+}
+
+// ================================================================
+// MCP PROMPT SYSTEM
+// ================================================================
+
+/**
+ * MCP Prompt argument definition
+ */
+export interface MCPPromptArgument {
+  name: string;
+  description?: string;
+  required?: boolean;
+}
+
+/**
+ * MCP Prompt definition
+ */
+export interface MCPPrompt {
+  name: string;
+  description?: string;
+  arguments?: MCPPromptArgument[];
+}
+
+/**
+ * MCP Get Prompt parameters
+ */
+export interface MCPGetPromptParams {
+  name: string;
+  arguments?: Record<string, string>;
+}
+
+/**
+ * MCP Prompt message
+ */
+export interface MCPPromptMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: {
+    type: 'text' | 'image' | 'resource';
+    text?: string;
+    data?: string;
+    mimeType?: string;
+    uri?: string;
+  };
+}
+
+/**
+ * MCP Get Prompt result
+ */
+export interface MCPGetPromptResult {
+  description?: string;
+  messages: MCPPromptMessage[];
+}
+
+/**
+ * MCP List Prompts result
+ */
+export interface MCPListPromptsResult {
+  prompts: MCPPrompt[];
+}
+
+// ================================================================
+// MCP RESOURCE SYSTEM
+// ================================================================
+
+/**
+ * MCP Resource definition
+ */
+export interface MCPResource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+  annotations?: {
+    audience?: string[];
+    priority?: number;
+  };
+}
+
+/**
+ * MCP Resource content
+ */
+export interface MCPResourceContent {
+  uri: string;
+  mimeType?: string;
+  text?: string;
+  blob?: Uint8Array;
+}
+
+/**
+ * MCP Read Resource parameters
+ */
+export interface MCPReadResourceParams {
+  uri: string;
+}
+
+/**
+ * MCP Read Resource result
+ */
+export interface MCPReadResourceResult {
+  contents: MCPResourceContent[];
+}
+
+/**
+ * MCP List Resources result
+ */
+export interface MCPListResourcesResult {
+  resources: MCPResource[];
+}
+
+/**
+ * MCP Subscribe to Resource parameters
+ */
+export interface MCPSubscribeResourceParams {
+  uri: string;
+}
+
+/**
+ * MCP Unsubscribe from Resource parameters
+ */
+export interface MCPUnsubscribeResourceParams {
+  uri: string;
+}
+
+/**
+ * MCP Resource List Changed notification
+ */
+export interface MCPResourceListChangedNotification {
+  method: 'notifications/resources/list_changed';
+  params?: unknown;
+}
+
+/**
+ * MCP Resource Updated notification
+ */
+export interface MCPResourceUpdatedNotification {
+  method: 'notifications/resources/updated';
+  params: {
+    uri: string;
+  };
+}
+
+// ================================================================
+// MCP LOGGING SYSTEM
+// ================================================================
+
+/**
+ * MCP Log levels
+ */
+export type MCPLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * MCP Log entry
+ */
+export interface MCPLogEntry {
+  level: MCPLogLevel;
+  data?: unknown;
+  logger?: string;
+}
+
+/**
+ * MCP Logging notification
+ */
+export interface MCPLoggingNotification {
+  method: 'notifications/message';
+  params: MCPLogEntry;
+}
+
+// ================================================================
+// MCP SAMPLING SYSTEM
+// ================================================================
+
+/**
+ * MCP Sampling request parameters
+ */
+export interface MCPSamplingParams {
+  messages: MCPPromptMessage[];
+  systemPrompt?: string;
+  includeContext?: string;
+  temperature?: number;
+  maxTokens?: number;
+  modelPreferences?: {
+    hints?: Array<{
+      name?: string;
+    }>;
+    costPriority?: number;
+    speedPriority?: number;
+    intelligencePriority?: number;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * MCP Sampling result
+ */
+export interface MCPSamplingResult {
+  model: string;
+  stopReason?: 'endTurn' | 'stopSequence' | 'maxTokens' | 'error';
+  role: 'assistant';
+  content: {
+    type: 'text';
+    text: string;
+  };
+}
+
+// ================================================================
+// MCP NOTIFICATIONS
+// ================================================================
+
+/**
+ * MCP Cancelled notification
+ */
+export interface MCPCancelledNotification {
+  method: 'notifications/cancelled';
+  params: {
+    requestId: string | number;
+    reason?: string;
+  };
+}
+
+/**
+ * MCP Progress notification
+ */
+export interface MCPProgressNotification {
+  method: 'notifications/progress';
+  params: {
+    progressToken: string | number;
+    progress?: number;
+    total?: number;
+  };
+}
+
+/**
+ * MCP Initialized notification
+ */
+export interface MCPInitializedNotification {
+  method: 'notifications/initialized';
+  params?: unknown;
+}
+
+/**
+ * Union type for all MCP notifications
+ */
+export type MCPNotification = 
+  | MCPResourceListChangedNotification
+  | MCPResourceUpdatedNotification
+  | MCPLoggingNotification
+  | MCPCancelledNotification
+  | MCPProgressNotification
+  | MCPInitializedNotification;
+
+// ================================================================
+// MCP TRANSPORT LAYER
+// ================================================================
+
+/**
+ * MCP Transport types
+ */
+export type MCPTransportType = 'stdio' | 'http' | 'websocket' | 'sse';
+
+/**
+ * Base MCP Transport interface
+ */
+export interface MCPTransport {
+  type: MCPTransportType;
+  send(message: JSONRPCMessage): Promise<void>;
+  close(): Promise<void>;
+  onMessage(handler: (message: JSONRPCMessage) => void): void;
+  onClose(handler: () => void): void;
+  onError(handler: (error: Error) => void): void;
+}
+
+/**
+ * STDIO Transport configuration
+ */
+export interface MCPStdioTransportConfig {
+  type: 'stdio';
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  timeout?: number;
+}
+
+/**
+ * HTTP Transport configuration
+ */
+export interface MCPHttpTransportConfig {
+  type: 'http';
+  url: string;
+  method?: 'POST' | 'GET';
+  headers?: Record<string, string>;
+  timeout?: number;
+  maxRetries?: number;
+  retryDelay?: number;
+}
+
+/**
+ * WebSocket Transport configuration
+ */
+export interface MCPWebSocketTransportConfig {
+  type: 'websocket';
+  url: string;
+  protocols?: string[];
+  headers?: Record<string, string>;
+  timeout?: number;
+  reconnectDelay?: number;
+  maxReconnectAttempts?: number;
+}
+
+/**
+ * Server-Sent Events Transport configuration
+ */
+export interface MCPSSETransportConfig {
+  type: 'sse';
+  url: string;
+  headers?: Record<string, string>;
+  timeout?: number;
+  reconnectDelay?: number;
+  maxReconnectAttempts?: number;
+}
+
+/**
+ * Union type for all transport configurations
+ */
+export type MCPTransportConfig = 
+  | MCPStdioTransportConfig
+  | MCPHttpTransportConfig
+  | MCPWebSocketTransportConfig
+  | MCPSSETransportConfig;
+
+// ================================================================
+// MCP SESSION MANAGEMENT
+// ================================================================
+
+/**
+ * MCP Session state
+ */
+export type MCPSessionState = 'disconnected' | 'connecting' | 'connected' | 'initializing' | 'initialized' | 'error';
+
+/**
+ * MCP Session interface
+ */
+export interface MCPSession {
+  id: string;
+  state: MCPSessionState;
+  transport: MCPTransport;
+  clientInfo?: MCPClientInfo;
+  serverInfo?: MCPServerInfo;
+  protocolVersion?: MCPProtocolVersion;
+  clientCapabilities?: MCPClientCapabilities;
+  serverCapabilities?: MCPServerCapabilities;
+  createdAt: Date;
+  lastActivity: Date;
+  metadata?: Record<string, unknown>;
+}
+
+// ================================================================
+// MCP CONTEXT AND EXECUTION
+// ================================================================
+
+/**
+ * MCP Execution context
+ */
+export interface MCPContext {
+  sessionId: string;
+  requestId?: string | number;
+  agentId?: string;
+  userId?: string;
+  permissions?: string[];
+  metadata?: Record<string, unknown>;
+  logger?: ILogger;
+  protocolVersion?: MCPProtocolVersion;
+  capabilities?: MCPCapabilities;
+  timeout?: number;
+  cancellationToken?: AbortSignal;
+}
+
+/**
+ * MCP Request context with additional Claude Flow extensions
+ */
+export interface MCPRequestContext extends MCPContext {
+  timestamp: Date;
+  source: 'client' | 'server';
+  method: string;
+  params?: unknown;
+  headers?: Record<string, string>;
+  route?: string;
+  rateLimitInfo?: {
+    limit: number;
+    remaining: number;
+    resetTime: Date;
+  };
+}
+
+// ================================================================
+// MCP AUTHENTICATION AND AUTHORIZATION
+// ================================================================
+
+/**
+ * MCP Authentication methods
+ */
+export type MCPAuthMethod = 'none' | 'token' | 'basic' | 'bearer' | 'oauth' | 'jwt' | 'custom';
+
+/**
+ * MCP Authentication configuration
+ */
+export interface MCPAuthConfig {
+  method: MCPAuthMethod;
+  token?: string;
+  username?: string;
+  password?: string;
+  bearerToken?: string;
+  jwtSecret?: string;
+  customAuth?: (context: MCPContext) => Promise<boolean>;
+  sessionTimeout?: number;
+  refreshToken?: string;
+  scopes?: string[];
+}
+
+/**
+ * MCP User permissions
+ */
+export interface MCPPermissions {
+  tools?: string[];
+  prompts?: string[];
+  resources?: string[];
+  admin?: boolean;
+  rateLimit?: {
+    requestsPerMinute: number;
+    burstLimit: number;
+  };
+}
+
+/**
+ * MCP Authentication result
+ */
+export interface MCPAuthResult {
+  authenticated: boolean;
+  userId?: string;
+  permissions?: MCPPermissions;
+  sessionToken?: string;
+  expiresAt?: Date;
+  metadata?: Record<string, unknown>;
+}
+
+// ================================================================
+// MCP METRICS AND MONITORING
+// ================================================================
+
+/**
+ * MCP Performance metrics
+ */
+export interface MCPMetrics {
+  requests: {
+    total: number;
+    successful: number;
+    failed: number;
+    cancelled: number;
+    averageLatency: number;
+    p95Latency: number;
+    p99Latency: number;
+  };
+  tools: {
+    invocations: Record<string, number>;
+    averageExecutionTime: Record<string, number>;
+    errorRate: Record<string, number>;
+  };
+  prompts: {
+    invocations: Record<string, number>;
+    averageExecutionTime: Record<string, number>;
+    errorRate: Record<string, number>;
+  };
+  resources: {
+    reads: Record<string, number>;
+    subscriptions: Record<string, number>;
+    errorRate: Record<string, number>;
+  };
+  sessions: {
+    active: number;
+    total: number;
+    averageDuration: number;
+  };
+  transport: {
+    messagesSent: number;
+    messagesReceived: number;
+    bytesTransferred: number;
+    connectionErrors: number;
+  };
+  errors: Record<string, number>;
+  timestamp: Date;
+}
+
+/**
+ * MCP Health check result
+ */
+export interface MCPHealthCheck {
+  status: 'healthy' | 'degraded' | 'unhealthy';
+  checks: {
+    transport: 'healthy' | 'degraded' | 'unhealthy';
+    authentication: 'healthy' | 'degraded' | 'unhealthy';
+    tools: 'healthy' | 'degraded' | 'unhealthy';
+    prompts: 'healthy' | 'degraded' | 'unhealthy';
+    resources: 'healthy' | 'degraded' | 'unhealthy';
+    memory: 'healthy' | 'degraded' | 'unhealthy';
+  };
+  metrics: MCPMetrics;
+  timestamp: Date;
+  uptime: number;
+}
+
+// ================================================================
+// MCP CONFIGURATION
+// ================================================================
+
+/**
+ * MCP Server configuration
+ */
+export interface MCPServerConfig {
+  name: string;
+  version: string;
+  description?: string;
+  transport: MCPTransportConfig;
+  auth?: MCPAuthConfig;
+  capabilities?: MCPServerCapabilities;
+  tools?: MCPTool[];
+  prompts?: MCPPrompt[];
+  resources?: MCPResource[];
+  logging?: {
+    level: MCPLogLevel;
+    format: 'json' | 'text';
+    destination: 'console' | 'file' | 'both';
+    filePath?: string;
+  };
+  limits?: {
+    maxSessions: number;
+    maxRequestsPerSession: number;
+    maxRequestSize: number;
+    maxResponseSize: number;
+    requestTimeout: number;
+    sessionTimeout: number;
+  };
+  cors?: {
+    enabled: boolean;
+    origins: string[];
+    methods: string[];
+    headers: string[];
+  };
+  rateLimit?: {
+    enabled: boolean;
+    requestsPerMinute: number;
+    burstLimit: number;
+    windowMs: number;
+  };
+  monitoring?: {
+    enabled: boolean;
+    metricsInterval: number;
+    healthCheckInterval: number;
+  };
+  middleware?: Array<(context: MCPContext, next: () => Promise<void>) => Promise<void>>;
+}
+
+/**
+ * MCP Client configuration
+ */
+export interface MCPClientConfig {
+  name: string;
+  version: string;
+  transport: MCPTransportConfig;
+  auth?: MCPAuthConfig;
+  capabilities?: MCPClientCapabilities;
+  timeout?: number;
+  retryPolicy?: {
+    maxRetries: number;
+    retryDelay: number;
+    backoffMultiplier: number;
+  };
+  logging?: {
+    level: MCPLogLevel;
+    enabled: boolean;
+  };
+  middleware?: Array<(context: MCPContext, next: () => Promise<void>) => Promise<void>>;
+}
+
+// ================================================================
+// MCP EVENTS AND HOOKS
+// ================================================================
+
+/**
+ * MCP Event types
+ */
+export type MCPEventType = 
+  | 'session:created'
+  | 'session:initialized'
+  | 'session:closed'
+  | 'session:error'
+  | 'tool:called'
+  | 'tool:completed'
+  | 'tool:failed'
+  | 'prompt:called'
+  | 'prompt:completed'
+  | 'prompt:failed'
+  | 'resource:read'
+  | 'resource:subscribed'
+  | 'resource:unsubscribed'
+  | 'resource:updated'
+  | 'message:sent'
+  | 'message:received'
+  | 'error:occurred'
+  | 'metrics:collected';
+
+/**
+ * MCP Event data
+ */
+export interface MCPEvent {
+  type: MCPEventType;
+  sessionId: string;
+  timestamp: Date;
+  data: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * MCP Event emitter interface
+ */
+export interface MCPEventEmitter extends EventEmitter {
+  emit(event: MCPEventType, data: MCPEvent): boolean;
+  on(event: MCPEventType, listener: (data: MCPEvent) => void): this;
+  once(event: MCPEventType, listener: (data: MCPEvent) => void): this;
+  off(event: MCPEventType, listener: (data: MCPEvent) => void): this;
+}
+
+// ================================================================
+// MCP UTILITY TYPES
+// ================================================================
+
+/**
+ * Type guard for MCP requests
+ */
+export function isMCPRequest(message: JSONRPCMessage): message is JSONRPCRequest {
+  return 'id' in message && 'method' in message;
+}
+
+/**
+ * Type guard for MCP responses
+ */
+export function isMCPResponse(message: JSONRPCMessage): message is JSONRPCResponse {
+  return 'id' in message && ('result' in message || 'error' in message);
+}
+
+/**
+ * Type guard for MCP notifications
+ */
+export function isMCPNotification(message: JSONRPCMessage): message is JSONRPCNotification {
+  return 'method' in message && !('id' in message);
+}
+
+/**
+ * Type guard for MCP errors
+ */
+export function isMCPError(obj: unknown): obj is MCPError {
+  return typeof obj === 'object' && obj !== null && 'code' in obj && 'message' in obj;
+}
+
+/**
+ * Utility type for extracting tool names from a tool array
+ */
+export type ExtractToolNames<T extends readonly MCPTool[]> = T[number]['name'];
+
+/**
+ * Utility type for extracting prompt names from a prompt array
+ */
+export type ExtractPromptNames<T extends readonly MCPPrompt[]> = T[number]['name'];
+
+/**
+ * Utility type for making all properties optional recursively
+ */
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+/**
+ * Utility type for making all properties required recursively
+ */
+export type DeepRequired<T> = {
+  [P in keyof T]-?: T[P] extends object ? DeepRequired<T[P]> : T[P];
+};
+
+/**
+ * Utility type for extracting the return type of a tool handler
+ */
+export type ToolHandlerReturnType<T extends MCPTool> = 
+  T['handler'] extends (input: any, context?: any) => Promise<infer R> ? R : never;
+
+// ================================================================
+// MCP EXTENSIONS FOR CLAUDE FLOW
+// ================================================================
+
+/**
+ * Claude Flow specific MCP extensions
+ */
+export interface ClaudeFlowMCPExtensions {
+  swarm?: {
+    enabled: boolean;
+    agentTypes: string[];
+    coordinationMode: 'hierarchical' | 'mesh' | 'ring' | 'star';
+    maxAgents: number;
+  };
+  memory?: {
+    enabled: boolean;
+    backend: 'sqlite' | 'markdown' | 'hybrid';
+    namespace: string;
+    ttl?: number;
+  };
+  terminal?: {
+    enabled: boolean;
+    type: 'vscode' | 'native' | 'auto';
+    poolSize: number;
+  };
+  neural?: {
+    enabled: boolean;
+    models: string[];
+    trainingMode: 'online' | 'offline' | 'hybrid';
+  };
+}
+
+/**
+ * Extended MCP Context with Claude Flow features
+ */
+export interface ClaudeFlowMCPContext extends MCPContext {
+  swarmId?: string;
+  coordinationData?: Record<string, unknown>;
+  memoryNamespace?: string;
+  terminalId?: string;
+  neuralModelId?: string;
+  extensions?: ClaudeFlowMCPExtensions;
+}
+
+/**
+ * Claude Flow MCP Tool with enhanced capabilities
+ */
+export interface ClaudeFlowMCPTool extends MCPTool {
+  category?: string;
+  tags?: string[];
+  permissions?: string[];
+  rateLimit?: {
+    requestsPerMinute: number;
+    burstLimit: number;
+  };
+  caching?: {
+    enabled: boolean;
+    ttl: number;
+    keyGenerator?: (input: unknown) => string;
+  };
+  validation?: {
+    enabled: boolean;
+    customValidator?: (input: unknown) => Promise<boolean>;
+  };
+  monitoring?: {
+    enabled: boolean;
+    trackMetrics: boolean;
+    alertOnErrors: boolean;
+  };
+  handler: (input: unknown, context?: ClaudeFlowMCPContext) => Promise<unknown>;
+}
+
+// ================================================================
+// EXPORTED TYPES FOR CONVENIENCE
+// ================================================================
+
+/**
+ * Main MCP namespace export
+ */
+export namespace MCP {
+  // Core types
+  export type ProtocolVersion = MCPProtocolVersion;
+  export type Error = MCPError;
+  export type Capabilities = MCPCapabilities;
+  export type Context = MCPContext;
+  export type Session = MCPSession;
+  export type Transport = MCPTransport;
+  export type TransportConfig = MCPTransportConfig;
+  
+  // Tool system
+  export type Tool = MCPTool;
+  export type ToolResult = MCPToolResult;
+  export type ToolContent = MCPToolContent;
+  export type ToolCall = MCPToolCallParams;
+  
+  // Prompt system
+  export type Prompt = MCPPrompt;
+  export type PromptArgument = MCPPromptArgument;
+  export type PromptMessage = MCPPromptMessage;
+  
+  // Resource system
+  export type Resource = MCPResource;
+  export type ResourceContent = MCPResourceContent;
+  
+  // Messaging
+  export type Request = JSONRPCRequest;
+  export type Response = JSONRPCResponse;
+  export type Notification = JSONRPCNotification;
+  export type Message = JSONRPCMessage;
+  
+  // Configuration
+  export type ServerConfig = MCPServerConfig;
+  export type ClientConfig = MCPClientConfig;
+  export type AuthConfig = MCPAuthConfig;
+  
+  // Monitoring
+  export type Metrics = MCPMetrics;
+  export type HealthCheck = MCPHealthCheck;
+  export type Event = MCPEvent;
+  
+  // Claude Flow extensions
+  export type ClaudeFlowContext = ClaudeFlowMCPContext;
+  export type ClaudeFlowTool = ClaudeFlowMCPTool;
+  export type ClaudeFlowExtensions = ClaudeFlowMCPExtensions;
+}
+
+// Default export for the main namespace
+export default MCP;


### PR DESCRIPTION
Converts the Model Context Protocol (MCP) integration wrapper from JavaScript to TypeScript as requested in issue #305. This PR enhances type safety and protocol communication reliability while maintaining full backward compatibility.

## Key Changes:
- Converted src/mcp/ruv-swarm-wrapper.js → src/mcp/ruv-swarm-wrapper.ts
- Converted src/mcp/mcp-server.js → src/mcp/mcp-server.ts  
- Added comprehensive TypeScript type definitions
- Added runtime type validation utilities
- Added type-safe protocol serialization
- All MCP tests pass (23/23)
- TypeScript compilation successful

## Definition of Done:
✅ MCP integration is fully type-safe
✅ Protocol communication has proper types
✅ Tool definitions are completely typed
✅ All MCP functionality works correctly

Closes #305