### PR TITLE
fix: resolve hook and settings.json issues

### DIFF
--- a/src/cli/simple-commands/hooks.js
+++ b/src/cli/simple-commands/hooks.js
@@ -438,7 +438,16 @@ async function postTaskCommand(subArgs, flags) {
 async function postEditCommand(subArgs, flags) {
   const options = flags;
   const file = options.file || 'unknown-file';
-  const memoryKey = options['memory-key'] || options.memoryKey;
+  let memoryKey = options['memory-key'] || options.memoryKey;
+  
+  // Handle case where memory-key is passed as a boolean flag without value
+  if (memoryKey === true) {
+    // Generate a default memory key based on the file path and timestamp
+    const path = await import('path');
+    const basename = path.basename(file);
+    memoryKey = `edit:${basename}:${Date.now()}`;
+  }
+  
   const format = options.format || false;
   const updateMemory = options['update-memory'] || false;
   const trainNeural = options['train-neural'] || false;
@@ -566,7 +575,7 @@ async function postEditCommand(subArgs, flags) {
       metadata: { hookType: 'post-edit', file, formatted: formatResult?.attempted || false },
     });
 
-    if (memoryKey) {
+    if (memoryKey && typeof memoryKey === 'string') {
       await store.store(
         memoryKey,
         {

--- a/src/cli/simple-commands/init/templates/settings.json
+++ b/src/cli/simple-commands/init/templates/settings.json
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | tr '\n' '\0' | xargs -0 -I {} npx claude-flow@alpha hooks pre-command --command '{}' --validate-safety true --prepare-resources true"
+            "command": "cat | jq -r '.tool_input.command // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks pre-command --command '{}' --validate-safety true --prepare-resources true"
           }
         ]
       },
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\n' '\0' | xargs -0 -I {} npx claude-flow@alpha hooks pre-edit --file '{}' --auto-assign-agents true --load-context true"
+            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks pre-edit --file '{}' --auto-assign-agents true --load-context true"
           }
         ]
       }
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | tr '\n' '\0' | xargs -0 -I {} npx claude-flow@alpha hooks post-command --command '{}' --track-metrics true --store-results true"
+            "command": "cat | jq -r '.tool_input.command // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks post-command --command '{}' --track-metrics true --store-results true"
           }
         ]
       },
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\n' '\0' | xargs -0 -I {} npx claude-flow@alpha hooks post-edit --file '{}' --format true --update-memory true"
+            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks post-edit --file '{}' --format true --update-memory true"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Fixed SQLite binding error in post-edit hook when `--memory-key` is passed without a value
- Fixed escape sequences in settings.json template for proper JSON parsing by Claude CLI

## Changes

### 1. Post-edit Hook Fix
- When `--memory-key` flag is passed without a value, it's parsed as boolean `true`
- This caused SQLite binding errors: "SQLite3 can only bind numbers, strings, bigints, buffers, and null"
- Now generates a default memory key based on filename and timestamp when the flag is boolean

### 2. Settings.json Template Fix
- The template had single backslashes `\n` that were interpreted as actual newlines
- This caused Claude CLI to report invalid JSON
- Fixed by using double backslashes `\\n` for proper escaping in the `tr` commands

## Test Plan
- [x] Tested `npx claude-flow@alpha hooks post-edit --file "file.ts" --memory-key` - now works without errors
- [x] Tested `npx claude-flow@alpha init --force` - creates valid settings.json that passes jq validation
- [x] Verified Claude CLI no longer reports invalid settings files

🤖 Generated with [Claude Code](https://claude.ai/code)