### PR TITLE
fix(windows): Resolve CLI path normalization bug preventing command execution

### DIFF
--- a/src/cli/node-compat.js
+++ b/src/cli/node-compat.js
@@ -6,7 +6,7 @@
 import { readdir, stat, mkdir, readFile, writeFile, unlink, rmdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { dirname, join, normalize } from 'path';
 import process from 'process';
 import { spawn } from 'child_process';
 
@@ -163,7 +163,7 @@ export const getFilename = (importMetaUrl) => {
 // Check if this is the main module (Node.js equivalent of import.meta.main)
 export const isMainModule = (importMetaUrl) => {
   const __filename = fileURLToPath(importMetaUrl);
-  return process.argv[1] === __filename;
+  return normalize(process.argv[1]) === normalize(__filename);
 };
 
 // Helper to check file existence


### PR DESCRIPTION
Critical Windows compatibility fix that resolves silent CLI command failures. The isMainModule function was failing on Windows due to direct string comparison of file paths with different separators. This commit fixes the issue by normalizing both paths using path.normalize() before comparison. Fixes silent CLI command failures on Windows where commands like claude-flow memory stats would run without output. Tested on Windows 11 with Node.js v22.17.0.