### PR TITLE
Fix cross platform (win32) claude detection in simple commands

### DIFF
--- a/src/cli/simple-commands/github.js
+++ b/src/cli/simple-commands/github.js
@@ -148,9 +148,15 @@ export async function githubCommand(args, flags) {
   try {
     // Check if Claude is available
     const { execSync } = await import('child_process');
-    
+    const os = await import('node:os');
     try {
-      execSync('which claude', { stdio: 'ignore' });
+      if (os.platform() === 'win32') {
+        // Windows: Use 'where' command
+        execSync('where claude', { stdio: 'ignore' });
+      } else {
+        // Unix-like systems: Use 'which' command
+        execSync('which claude', { stdio: 'ignore' });
+      }
     } catch (e) {
       printWarning('⚠️  Claude CLI not found. GitHub automation requires Claude.');
       console.log('Install Claude: https://claude.ai/code');

--- a/src/cli/simple-commands/hive-mind.js
+++ b/src/cli/simple-commands/hive-mind.js
@@ -1480,10 +1480,17 @@ async function spawnClaudeCodeInstances(swarmId, swarmName, objective, workers, 
     try {
       // Check if claude command exists
       const { spawn: childSpawn, execSync } = await import('child_process');
+      const os = await import('node:os');
       let claudeAvailable = false;
       
       try {
-        execSync('which claude', { stdio: 'ignore' });
+        if (os.platform() === 'win32') {
+          // Windows: Use 'where' command
+          execSync('where claude', { stdio: 'ignore' });
+        } else {
+          // Unix-like systems: Use 'which' command
+          execSync('which claude', { stdio: 'ignore' });
+        }
         claudeAvailable = true;
       } catch {
         console.log(chalk.yellow('\n⚠️  Claude Code CLI not found in PATH'));

--- a/src/cli/simple-commands/init/index.js
+++ b/src/cli/simple-commands/init/index.js
@@ -53,11 +53,27 @@ import {
 /**
  * Check if Claude Code CLI is installed
  */
-function isClaudeCodeInstalled() {
+// At the top of your module
+let claudeCodeInstalledPromise = null;
+
+async function isClaudeCodeInstalled() {
+  if (claudeCodeInstalledPromise) {
+    return claudeCodeInstalledPromise;
+  }
+  
+  claudeCodeInstalledPromise = checkClaudeCodeInstallation();
+  return claudeCodeInstalledPromise;
+}
+
+async function checkClaudeCodeInstallation() {
   try {
-    execSync('which claude', { stdio: 'ignore' });
+    const { exec } = await import('child_process');
+    const { promisify } = await import('util');
+    const execAsync = promisify(exec);
+    
+    await execAsync('claude --version');
     return true;
-  } catch {
+  } catch (error) {
     return false;
   }
 }
@@ -1132,7 +1148,7 @@ ${commands.map(cmd => `- [${cmd}](./${cmd}.md)`).join('\n')}
     // Final instructions
     console.log('\n🎉 Claude Flow v2.0.0 initialization complete!');
     console.log('\n📚 Quick Start:');
-    if (isClaudeCodeInstalled()) {
+    if (await isClaudeCodeInstalled()) {
       console.log('1. View available commands: ls .claude/commands/');
       console.log('2. Start a swarm: npx claude-flow swarm init');
       console.log('3. Use MCP tools in Claude Code for enhanced coordination');

--- a/src/cli/simple-commands/swarm.js
+++ b/src/cli/simple-commands/swarm.js
@@ -107,11 +107,18 @@ export async function swarmCommand(args, flags) {
     // Default behavior: spawn Claude Code with comprehensive swarm MCP instructions
     try {
       const { execSync, spawn } = await import('child_process');
-      
+      const os = await import('node:os');
+
       // Check if claude command exists
       let claudeAvailable = false;
       try {
-        execSync('which claude', { stdio: 'ignore' });
+        if (os.platform() === 'win32') {
+          // Windows: Use 'where' command
+          execSync('where claude', { stdio: 'ignore' });
+        } else {
+          // Unix-like systems: Use 'which' command
+          execSync('which claude', { stdio: 'ignore' });
+        }
         claudeAvailable = true;
       } catch {
         console.log('⚠️  Claude Code CLI not found in PATH');
@@ -857,10 +864,16 @@ exit 0
       // Try to use Claude wrapper approach like SPARC does
       try {
         const { execSync } = await import('child_process');
-        
+        const os = await import('node:os');
         // Check if claude command exists
         try {
-          execSync('which claude', { stdio: 'ignore' });
+          if (os.platform() === 'win32') {
+            // Windows: Use 'where' command
+            execSync('where claude', { stdio: 'ignore' });
+          } else {
+            // Unix-like systems: Use 'which' command
+            execSync('which claude', { stdio: 'ignore' });
+          }
         } catch (e) {
           // Claude not found, show fallback message
           console.log(`✅ Swarm initialized with ID: ${swarmId}`);

--- a/src/cli/swarm-standalone.js
+++ b/src/cli/swarm-standalone.js
@@ -109,10 +109,15 @@ if (!swarmPath) {
   // Try to use Claude wrapper approach
   try {
     const { execSync } = await import('child_process');
-    
+    const os = await import('node:os');
     // Check if claude command exists
     try {
-      execSync('which claude', { stdio: 'ignore' });
+      if (os.platform() === 'win32') {
+        // Windows: Use 'where' command
+        execSync('where claude', { stdio: 'ignore' });
+      } else {
+        execSync('which claude', { stdio: 'ignore' });
+      }
     } catch (e) {
       // Claude not found, show fallback message
       console.log(`✅ Swarm initialized with ID: ${swarmId}`);


### PR DESCRIPTION
## Summary
Simple fix to js commands to detect claude on win32 environments

## Changes Made
Expanded the simple test ("which claude") to check node:os.platform() and use "where claude" is on win32. Changes made to:
src/cli/swarm-standalone.js
src/cli/simple-commands/github.js
src/cli/simple-commands/hive-mind.js
src/cli/simple-commands/swarm.js
src/cli/simple-commands/init/index.js

## Testing
Manually tested.  Attempted to run tests but the results indicated a lot of unrelated errors and I'm not sure I trust my environment.  I did not see any js related CLI test errors, however.