### PR TITLE
Fix: Read port from config file for UI and web server

### DIFF
--- a/src/cli/simple-commands/start-wrapper.js
+++ b/src/cli/simple-commands/start-wrapper.js
@@ -13,7 +13,21 @@ export async function startCommand(subArgs, flags) {
 
   // Parse start options
   const daemon = subArgs.includes('--daemon') || subArgs.includes('-d') || flags.daemon;
-  const port = flags.port || getArgValue(subArgs, '--port') || getArgValue(subArgs, '-p') || 3000;
+  
+  // Try to read port from config file first
+  let defaultPort = 3000;
+  try {
+    const configFile = 'claude-flow.config.json';
+    if (existsSync(configFile)) {
+      const config = JSON.parse(await fs.readFile(configFile, 'utf8'));
+      // Check both server.port and mcp.port for compatibility
+      defaultPort = config?.server?.port || config?.mcp?.port || 3000;
+    }
+  } catch (err) {
+    // Ignore config read errors, use default
+  }
+  
+  const port = flags.port || getArgValue(subArgs, '--port') || getArgValue(subArgs, '-p') || defaultPort;
   const verbose = subArgs.includes('--verbose') || subArgs.includes('-v') || flags.verbose;
   const ui = subArgs.includes('--ui') || subArgs.includes('-u') || flags.ui;
   const web = subArgs.includes('--web') || subArgs.includes('-w') || flags.web;


### PR DESCRIPTION
## Summary
This PR fixes an issue where the `--ui` flag would always use port 3000 even when a different port was configured in `claude-flow.config.json`.

## Problem
In active development environments, port 3000 is often already in use by other services. Users can configure a custom port using:
```bash
npx claude-flow config set server.port 33000
```

However, when running `claude-flow start --ui`, the system would still try to use port 3000, causing an `EADDRINUSE` error.

## Solution
Modified `start-wrapper.js` to read the port configuration from `claude-flow.config.json` before defaulting to port 3000.

## Changes
- Added config file reading logic to check for configured port
- Checks both `server.port` and `mcp.port` for compatibility with different config versions
- Falls back gracefully to port 3000 if config file doesn't exist or can't be read
- Maintains backward compatibility - existing setups without config continue to work

## Testing
- Tested with configured port 33000 - UI starts successfully on configured port
- Tested without config file - defaults to port 3000 as expected
- Tested with explicit `--port` flag - command line argument takes precedence

## Impact
This change allows users in busy development environments to set a global port configuration that will be respected by all claude-flow commands, preventing port conflicts and improving developer experience.

🤖 Generated with Claude Code