### PR TITLE
doc: warn against running claude outside of a sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ npm install -g @anthropic-ai/claude-code
 claude --dangerously-skip-permissions
 ```
 
+> [!CAUTION]
+> If you run `claude --dangerously-skip-permissions` locally outside of a sandbox (like `Docker`) `claude` will likely be able access any credentials you have locally & may even brick your machine (by editing your drivers) rendering it unusable. Please run it in either a sandbox or in an ephemeral cloud environment (like `GitHub Codespaces`) so that it cannot do so!  
+
 💡 **Windows Note**: If you encounter SQLite errors, Claude Flow will automatically use in-memory storage. For persistent storage options, see our [Windows guide](https://github.com/ruvnet/claude-code-flow/blob/main/docs/windows-installation.md).
 
 ### 🎯 **Instant Alpha Testing**


### PR DESCRIPTION
I saw you used to have guidance on running in a `Docker` container, however, this was moved to `/archive` in https://github.com/ruvnet/claude-flow/commit/d08abc6e490239fe1724eed160d66657da06003f

I couldn't see a plan for sandboxing outlined anywhere, so I thought this warning might suffice for now!

Happy to help here, I've used `Docker` quite a bit :)